### PR TITLE
Implement basic authentication components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,6 +30,7 @@
               }
             ],
             "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles.scss"
             ]
           },
@@ -88,6 +89,7 @@
               }
             ],
             "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles.scss"
             ]
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "bootstrap": "^5.3.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -2991,6 +2992,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.44.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
@@ -3719,6 +3731,25 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@angular/router": "^20.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "bootstrap": "^5.3.3"
   },
   "devDependencies": {
     "@angular/build": "^20.0.6",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,12 +1,15 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { tokenInterceptor } from './auth/token.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient(withInterceptors([tokenInterceptor]))
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,14 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'login',
+    loadComponent: () => import('./auth/login/login.component').then(m => m.LoginComponent)
+  },
+  {
+    path: 'register',
+    loadComponent: () => import('./auth/create-company/create-company.component').then(m => m.CreateCompanyComponent)
+  },
+  { path: '', redirectTo: 'login', pathMatch: 'full' },
+  { path: '**', redirectTo: 'login' }
+];

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { tap } from 'rxjs/operators';
+
+interface LoginResponse { token: string; }
+interface LoginPayload { email: string; password: string; }
+interface RegisterPayload { name: string; email: string; password: string; }
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  private _token = signal<string | null>(localStorage.getItem('token'));
+
+  /** Readonly token signal */
+  readonly token = this._token.asReadonly();
+
+  /** Emits true when a token exists */
+  readonly isLoggedIn = computed(() => !!this._token());
+
+  /** Performs the login request and stores the received JWT */
+  login(payload: LoginPayload) {
+    return this.http.post<LoginResponse>('/api/login', payload).pipe(
+      tap(res => this.setToken(res.token))
+    );
+  }
+
+  /** Registers a new company in the backend */
+  registerCompany(payload: RegisterPayload) {
+    return this.http.post('/api/register', payload);
+  }
+
+  /** Clears the stored token */
+  logout(): void {
+    this.setToken(null);
+  }
+
+  /** Retrieves the current JWT value */
+  getToken(): string | null {
+    return this._token();
+  }
+
+  private setToken(token: string | null): void {
+    this._token.set(token);
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+  }
+}

--- a/src/app/auth/create-company/create-company.component.html
+++ b/src/app/auth/create-company/create-company.component.html
@@ -1,0 +1,23 @@
+<div class="container d-flex justify-content-center align-items-center min-vh-100">
+  <form [formGroup]="form" (ngSubmit)="submit()" class="card p-4 w-100" style="max-width: 500px;">
+    <h2 class="mb-3 text-center">Register Company</h2>
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input id="name" type="text" formControlName="name" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input id="email" type="email" formControlName="email" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input id="password" type="password" formControlName="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary w-100" [disabled]="loading() || form.invalid">
+      {{ loading() ? 'Saving...' : 'Create' }}
+    </button>
+    <p class="mt-3 text-center">
+      <a routerLink="/login">Back to login</a>
+    </p>
+  </form>
+</div>

--- a/src/app/auth/create-company/create-company.component.ts
+++ b/src/app/auth/create-company/create-company.component.ts
@@ -1,0 +1,41 @@
+import { Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-create-company',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './create-company.component.html'
+})
+export class CreateCompanyComponent {
+  private fb = inject(FormBuilder);
+  private router = inject(Router);
+  private auth = inject(AuthService);
+
+  loading = signal(false);
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  /** Registers a new company and returns to login on success */
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.loading.set(true);
+    this.auth.registerCompany(this.form.getRawValue()).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.router.navigateByUrl('/login');
+      },
+      error: () => this.loading.set(false)
+    });
+  }
+}

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -1,0 +1,19 @@
+<div class="container d-flex justify-content-center align-items-center min-vh-100">
+  <form [formGroup]="form" (ngSubmit)="submit()" class="card p-4 w-100" style="max-width: 400px;">
+    <h2 class="mb-3 text-center">Login</h2>
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input id="email" type="email" formControlName="email" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input id="password" type="password" formControlName="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary w-100" [disabled]="loading() || form.invalid">
+      {{ loading() ? 'Loading...' : 'Login' }}
+    </button>
+    <p class="mt-3 text-center">
+      <a routerLink="/register">Create company</a>
+    </p>
+  </form>
+</div>

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -1,0 +1,40 @@
+import { Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './login.component.html'
+})
+export class LoginComponent {
+  private fb = inject(FormBuilder);
+  private router = inject(Router);
+  private auth = inject(AuthService);
+
+  loading = signal(false);
+
+  form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  /** Handles form submission and navigates on success */
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.loading.set(true);
+    this.auth.login(this.form.getRawValue()).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.router.navigateByUrl('/register');
+      },
+      error: () => this.loading.set(false)
+    });
+  }
+}

--- a/src/app/auth/token.interceptor.ts
+++ b/src/app/auth/token.interceptor.ts
@@ -1,0 +1,13 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+/** Intercepts HTTP requests and appends the Authorization header if available */
+export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};


### PR DESCRIPTION
## Summary
- add login and company registration standalone components
- provide AuthService using signals for JWT state
- create HTTP interceptor for automatic token injection
- wire routes for login and registration
- configure HttpClient and bootstrap styles

## Testing
- `npm install`
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_68825de7f1c483258d66d065011e1520