### PR TITLE
Implement basic private area with dashboard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,10 @@ export const routes: Routes = [
     path: 'register',
     loadComponent: () => import('./auth/create-company/create-company.component').then(m => m.CreateCompanyComponent)
   },
+  {
+    path: 'private',
+    loadChildren: () => import('./private/private.routes').then(m => m.PRIVATE_ROUTES)
+  },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: '**', redirectTo: 'login' }
 ];

--- a/src/app/private/agents/agents.component.html
+++ b/src/app/private/agents/agents.component.html
@@ -1,0 +1,4 @@
+<div class="container">
+  <h1>Agents</h1>
+  <p>Contenido de ejemplo.</p>
+</div>

--- a/src/app/private/agents/agents.component.ts
+++ b/src/app/private/agents/agents.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-agents',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './agents.component.html'
+})
+export class AgentsComponent {}

--- a/src/app/private/auth.guard.ts
+++ b/src/app/private/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+
+/** Simple authentication guard */
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isLoggedIn()) {
+    return true;
+  }
+  return router.createUrlTree(['/login']);
+};

--- a/src/app/private/dashboard/dashboard.component.html
+++ b/src/app/private/dashboard/dashboard.component.html
@@ -1,0 +1,33 @@
+<div class="container">
+  <h1 class="mb-4">Dashboard</h1>
+
+  <div class="row mb-4">
+    <div class="col-6 col-lg-3 mb-3" *ngFor="let m of metrics">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <h5 class="card-title">{{ m.title }}</h5>
+          <p class="display-6 fw-bold mb-0">{{ m.value }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6 mb-3">
+      <div class="card h-100">
+        <div class="card-header">Acceso rápido</div>
+        <div class="card-body">
+          <button class="btn btn-primary me-2 mb-2" *ngFor="let a of actions">{{ a }}</button>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6 mb-3">
+      <div class="card h-100">
+        <div class="card-header">Actividad reciente</div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item" *ngFor="let l of logs">{{ l }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/private/dashboard/dashboard.component.ts
+++ b/src/app/private/dashboard/dashboard.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './dashboard.component.html'
+})
+export class DashboardComponent {
+  metrics = [
+    { title: 'Formaciones completadas', value: 12 },
+    { title: 'Documentos indexados', value: 340 },
+    { title: 'Puntuaci\u00f3n media', value: '4.5/5' },
+    { title: 'Agentes activos', value: 5 }
+  ];
+
+  actions = ['Nuevo documento', 'Crear agente', 'Lanzar training'];
+
+  logs = [
+    'Usuario Juan cre\u00f3 un agente',
+    'Se index\u00f3 el documento Manual.pdf',
+    'Actualizada la formaci\u00f3n B\u00e1sica'
+  ];
+}

--- a/src/app/private/layout/private-layout.component.html
+++ b/src/app/private/layout/private-layout.component.html
@@ -1,0 +1,51 @@
+<!-- Toggle button visible on small screens -->
+<button class="btn btn-light d-md-none m-2" (click)="menuOpen.set(true)">
+  <i class="bi bi-list"></i>
+</button>
+
+<!-- Offcanvas menu for mobile -->
+<div class="offcanvas offcanvas-start" [class.show]="menuOpen()" tabindex="-1">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Menú</h5>
+    <button type="button" class="btn-close" (click)="menuOpen.set(false)"></button>
+  </div>
+  <div class="offcanvas-body p-0">
+    <ul class="nav nav-pills flex-column mb-auto">
+      <li class="nav-item">
+        <a class="nav-link" routerLink="/private/dashboard" (click)="menuOpen.set(false)">
+          <i class="bi bi-speedometer2 me-2"></i> Dashboard
+        </a>
+      </li>
+      <li>
+        <a class="nav-link" routerLink="/private/agents" (click)="menuOpen.set(false)">
+          <i class="bi bi-people me-2"></i> Agents
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+<div *ngIf="menuOpen()" class="offcanvas-backdrop fade show d-md-none" (click)="menuOpen.set(false)"></div>
+
+<div class="container-fluid">
+  <div class="row">
+    <!-- Static sidebar for md and above -->
+    <nav class="col-md-3 col-lg-2 d-none d-md-block bg-light p-3 min-vh-100">
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/private/dashboard">
+            <i class="bi bi-speedometer2 me-2"></i> Dashboard
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" routerLink="/private/agents">
+            <i class="bi bi-people me-2"></i> Agents
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <main class="col-12 col-md-9 ms-sm-auto col-lg-10 px-md-4 pt-3">
+      <router-outlet></router-outlet>
+    </main>
+  </div>
+</div>

--- a/src/app/private/layout/private-layout.component.ts
+++ b/src/app/private/layout/private-layout.component.ts
@@ -1,0 +1,14 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-private-layout',
+  standalone: true,
+  imports: [CommonModule, RouterLink, RouterOutlet],
+  templateUrl: './private-layout.component.html'
+})
+export class PrivateLayoutComponent {
+  /** Controls offcanvas visibility on small screens */
+  menuOpen = signal(false);
+}

--- a/src/app/private/private.routes.ts
+++ b/src/app/private/private.routes.ts
@@ -1,0 +1,22 @@
+import { Routes } from '@angular/router';
+import { authGuard } from './auth.guard';
+import { PrivateLayoutComponent } from './layout/private-layout.component';
+
+export const PRIVATE_ROUTES: Routes = [
+  {
+    path: '',
+    canActivate: [authGuard],
+    component: PrivateLayoutComponent,
+    children: [
+      {
+        path: 'dashboard',
+        loadComponent: () => import('./dashboard/dashboard.component').then(m => m.DashboardComponent)
+      },
+      {
+        path: 'agents',
+        loadComponent: () => import('./agents/agents.component').then(m => m.AgentsComponent)
+      },
+      { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
+    ]
+  }
+];

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- add PrivateLayout wrapper with responsive sidebar
- add Dashboard and Agents pages
- create AuthGuard and private routes
- wire private routes into main router
- include Bootstrap icons for menu visuals

## Testing
- `npm test` *(fails: could not run tests)*

------
https://chatgpt.com/codex/tasks/task_b_68826418da6c83258578f5ee4ceff6ed