### PR TITLE
Implement Transloco multi-loader and new Agent form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "@fortawesome/fontawesome-free": "^7.0.0",
         "@jsverse/transloco": "^7.6.1",
         "@ng-select/ng-select": "^15.1.3",
         "bootstrap": "^5.3.3",
@@ -1376,6 +1377,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.0.0.tgz",
+      "integrity": "sha512-X48nISrSOa89zu2VMljC4XaRf8NmgTwQBVHfS2Nu5G00ZwM31oOVrAtGxZF3b6wDYf9lJsf/Eq4cCSFKIkOWPQ==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@inquirer/checkbox": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
+    "@fortawesome/fontawesome-free": "^7.0.0",
     "@jsverse/transloco": "^7.6.1",
     "@ng-select/ng-select": "^15.1.3",
     "bootstrap": "^5.3.3",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,19 +8,11 @@ import {
 import { provideRouter } from '@angular/router';
 
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { provideTransloco } from '@jsverse/transloco';
+import { provideTransloco, provideTranslocoLoader } from '@jsverse/transloco';
 import { TableModule } from 'ng-hub-ui-table';
 import { routes } from './app.routes';
 import { tokenInterceptor } from './auth/token.interceptor';
-
-// @Injectable({ providedIn: 'root' })
-// export class TranslocoHttpLoader implements TranslocoLoader {
-//   private http = inject(HttpClient);
-
-//   getTranslation(lang: string) {
-//     return this.http.get<Translation>(`/assets/i18n/${lang}.json`);
-//   }
-// }
+import { TranslocoHttpLoader } from './shared/services/transloco-http.loader';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -32,11 +24,11 @@ export const appConfig: ApplicationConfig = {
       config: {
         availableLangs: ['en', 'es'],
         defaultLang: 'es',
-        // Remove this option if your application doesn't support changing language in runtime.
         reRenderOnLangChange: true,
         prodMode: true,
       },
     }),
+    provideTranslocoLoader(TranslocoHttpLoader),
     importProvidersFrom(NoopAnimationsModule, TableModule.forRoot()),
   ],
 };

--- a/src/app/auth/token.interceptor.ts
+++ b/src/app/auth/token.interceptor.ts
@@ -6,7 +6,7 @@ import { AuthService } from './auth.service';
 export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
   const token = auth.getToken();
-  if (token) {
+  if (!req.url.includes('/assets/i18n/') && token) {
     req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
   }
   return next(req);

--- a/src/app/private/agent-edition/agent-edition.component.html
+++ b/src/app/private/agent-edition/agent-edition.component.html
@@ -1,221 +1,39 @@
-<form [formGroup]="agentForm" (ngSubmit)="onCreateAgent()" class="space-y-8">
-  <!-- Header with Back Button -->
-  <div class="flex items-center space-x-2">
-    <button
-      type="button"
-      (click)="onGoBack()"
-      class="text-gray-500 hover:text-gray-700 transition-colors"
-    >
-      <svg
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-      >
-        <path d="M19 12H5"></path>
-        <path d="M12 19l-7-7 7-7"></path>
-      </svg>
+<form [formGroup]="form" (ngSubmit)="onSubmit()" class="container py-4 d-flex flex-column gap-3" (drop)="onDrop($event)" (dragover)="$event.preventDefault()">
+  <div class="d-flex mb-3">
+    <button type="button" class="btn btn-link me-2" routerLink="../">
+      <i class="fas fa-arrow-left"></i>
     </button>
-    <h1 class="text-3xl font-bold text-gray-900">Crear Nuevo Agente IA</h1>
+    <h1 class="h3 mb-0">{{ 'AGENT_EDITION.FORM.TITLE' | transloco }}</h1>
   </div>
 
-  <!-- Agent Name -->
-  <div class="space-y-3 bg-neutral-50 p-6 rounded-2xl shadow-sm">
-    <label for="agentName" class="block text-sm font-medium text-gray-700"
-      >Nombre del Agente</label
-    >
-    <input
-      id="agentName"
-      type="text"
-      formControlName="name"
-      class="w-full px-4 py-3 border rounded-2xl bg-neutral-50 focus:outline-none focus:ring-3 focus:ring-blue-100 placeholder-gray-400 transition-all"
-      [class.border-red-300]="isFieldInvalid('name')"
-      [class.border-gray-300]="!isFieldInvalid('name')"
-      [class.focus:border-blue-500]="!isFieldInvalid('name')"
-      [class.focus:border-red-500]="isFieldInvalid('name')"
-      placeholder="Ej. Agente de Soporte al Cliente"
-    />
-    @if (isFieldInvalid('name')) {
-    <div class="text-red-600 text-sm">
-      {{ getFieldError("Nombre") }}
-    </div>
-    }
+  <div class="mb-3">
+    <label class="form-label">{{ 'AGENT_EDITION.FORM.NAME' | transloco }}</label>
+    <input type="text" formControlName="name" class="form-control" />
   </div>
 
-  <!-- Agent Description -->
-  <div class="space-y-3 bg-neutral-50 p-6 rounded-2xl shadow-sm">
-    <label
-      for="agentDescription"
-      class="block text-sm font-medium text-gray-700"
-      >Descripción</label
-    >
-    <textarea
-      id="agentDescription"
-      rows="3"
-      formControlName="description"
-      class="w-full px-4 py-3 border rounded-2xl bg-neutral-50 focus:outline-none focus:ring-3 focus:ring-blue-100 placeholder-gray-400 resize-none transition-all"
-      [class.border-red-300]="isFieldInvalid('description')"
-      [class.border-gray-300]="!isFieldInvalid('description')"
-      [class.focus:border-blue-500]="!isFieldInvalid('description')"
-      [class.focus:border-red-500]="isFieldInvalid('description')"
-      placeholder="Describe la función y el propósito de este agente IA."
-    ></textarea>
-    @if (isFieldInvalid('description')) {
-    <div class="text-red-600 text-sm">
-      {{ getFieldError("Descripción") }}
-    </div>
-    }
+  <div class="mb-3">
+    <label class="form-label">{{ 'AGENT_EDITION.FORM.MODEL' | transloco }}</label>
+    <ng-select [items]="models" bindLabel="label" bindValue="value" formControlName="base_model_id"></ng-select>
   </div>
 
-  <!-- Agent Type Selection -->
-  <div class="space-y-4 bg-neutral-50 p-6 rounded-2xl shadow-sm">
-    <label class="block text-sm font-medium text-gray-700"
-      >Tipo de Agente</label
-    >
-    <div class="grid grid-cols-4 gap-4">
-      @for (agentType of agentTypes; track agentType) {
-      <button
-        type="button"
-        (click)="onSelectType(agentType.value)"
-        class="p-6 border rounded-2xl transition-all"
-        [ngClass]="{
-          'border-green-300 bg-green-50': type?.value === agentType.value,
-          'border-gray-200 bg-white hover:border-gray-300':
-            type?.value !== agentType.value
-        }"
-      >
-        <div class="flex flex-col items-center space-y-2">
-          <div class="text-2xl">{{ agentType.icon }}</div>
-          <span class="font-medium text-gray-800">{{ agentType.label }}</span>
-        </div>
-      </button>
-      }
+  <div class="mb-3">
+    <label class="form-label">{{ 'AGENT_EDITION.FORM.DESCRIPTION' | transloco }}</label>
+    <textarea rows="3" class="form-control" formControlName="description"></textarea>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">{{ 'AGENT_EDITION.FORM.UPLOAD_IMAGE' | transloco }}</label>
+    <div class="border rounded p-3 text-center">
+      <img *ngIf="imagePreview" [src]="imagePreview" class="img-thumbnail mb-2" alt="preview" />
+      <input type="file" accept="image/*" class="form-control" (change)="onFileSelect($event)" />
+      <small class="text-muted">{{ 'AGENT_EDITION.FORM.DRAG_DROP' | transloco }}</small>
     </div>
   </div>
 
-  <!-- File Upload Section -->
-  <div class="space-y-4 bg-neutral-50 p-6 rounded-2xl shadow-sm">
-    <label class="block text-sm font-medium text-gray-700"
-      >Cargar Datos para Entrenamiento</label
-    >
-
-    <!-- Error Message -->
-    @if (fileErrorMessage) {
-    <div
-      class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm"
-    >
-      {{ fileErrorMessage }}
-    </div>
-    }
-
-    <!-- Upload Area -->
-    <div
-      class="border-2 border-dashed rounded-2xl p-8 text-center transition-all duration-300"
-      [ngClass]="{
-        'border-blue-400 bg-blue-50 scale-105': isDragOver,
-        'border-green-400 bg-green-50': isDropping,
-        'border-gray-300 bg-white hover:border-gray-400 hover:bg-gray-50':
-          dragState === 'idle'
-      }"
-      (dragover)="onDragOver($event)"
-      (dragenter)="onDragEnter($event)"
-      (dragleave)="onDragLeave($event)"
-      (drop)="onDrop($event)"
-    >
-      <input
-        type="file"
-        id="fileUpload"
-        class="hidden"
-        (change)="onFileUpload($event)"
-        accept=".pdf,.doc,.docx,.txt"
-        multiple
-      />
-      <label for="fileUpload" class="cursor-pointer block">
-        <div class="space-y-3">
-          <div
-            class="text-5xl transition-all duration-300"
-            [ngClass]="{
-              'text-blue-500 animate-bounce': isDragOver,
-              'text-green-500': isDropping,
-              'text-gray-400': dragState === 'idle'
-            }"
-          >
-            📁
-          </div>
-          <div class="space-y-1">
-            <p
-              class="font-medium"
-              [ngClass]="{
-                'text-blue-600': isDragOver,
-                'text-green-600': isDropping,
-                'text-gray-700': dragState === 'idle'
-              }"
-            >
-              @if (dragState === 'idle') {
-              <span>Arrastra archivos aquí o haz clic para seleccionar</span>
-              } @if (isDragOver) {
-              <span>¡Suelta los archivos aquí!</span>
-              } @if (isDropping) {
-              <span>Procesando archivos...</span>
-              }
-            </p>
-            <p class="text-xs text-gray-500">
-              Formatos permitidos: PDF, DOC, DOCX, TXT (máx. 10MB)
-            </p>
-          </div>
-        </div>
-      </label>
-    </div>
-
-    <!-- Uploaded Files -->
-    @if (uploadedFiles.length > 0) {
-    <div class="space-y-2">
-      @for (file of uploadedFiles; track file) {
-      <div
-        class="flex items-center justify-between bg-white p-3 rounded-lg border border-gray-200"
-      >
-        <div class="flex items-center space-x-3">
-          <div class="text-gray-400">📄</div>
-          <span class="text-sm text-gray-700">{{ file }}</span>
-        </div>
-        <button
-          type="button"
-          (click)="onRemoveFile(file)"
-          class="text-gray-400 hover:text-red-500 transition-colors"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      }
-    </div>
-    }
+  <div class="form-check mb-3">
+    <input type="checkbox" class="form-check-input" formControlName="is_active" id="active" />
+    <label for="active" class="form-check-label">{{ 'AGENT_EDITION.FORM.IS_ACTIVE' | transloco }}</label>
   </div>
 
-  <!-- Create Button -->
-  <div class="flex justify-end pt-4">
-    <button
-      type="submit"
-      [disabled]="agentForm.invalid"
-      class="px-8 py-3 rounded-2xl font-medium transition-all duration-200"
-      [ngClass]="{
-        'bg-green-500 hover:bg-green-600 text-white shadow-lg hover:shadow-xl':
-          agentForm.valid,
-        'bg-gray-300 text-gray-500 cursor-not-allowed': agentForm.invalid
-      }"
-    >
-      Crear Agente
-    </button>
-  </div>
+  <button type="submit" class="btn btn-primary w-100">{{ 'AGENT_EDITION.FORM.CREATE' | transloco }}</button>
 </form>

--- a/src/app/private/agent-edition/agent-edition.component.spec.ts
+++ b/src/app/private/agent-edition/agent-edition.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AgentEdition } from './agent-edition';
+import { AgentEditionComponent } from './agent-edition.component';
 
-describe('AgentEdition', () => {
-  let component: AgentEdition;
-  let fixture: ComponentFixture<AgentEdition>;
+describe('AgentEditionComponent', () => {
+  let component: AgentEditionComponent;
+  let fixture: ComponentFixture<AgentEditionComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AgentEdition]
+      imports: [AgentEditionComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(AgentEdition);
+    fixture = TestBed.createComponent(AgentEditionComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/private/agent-list/agents.service.ts
+++ b/src/app/private/agent-list/agents.service.ts
@@ -19,4 +19,12 @@ export class AgentsService extends CollectionService<Agent> {
     // throw new Error('list not developed');
     return this.http.get<Array<Agent>>(`${environment.baseURL}/${this.path}/`);
   }
+
+  /** Creates a new agent */
+  createAgent(agent: Agent): Observable<Agent> {
+    return this.http.post<Agent>(
+      `${environment.baseURL}/${this.path}/create`,
+      agent
+    );
+  }
 }

--- a/src/app/shared/services/index.ts
+++ b/src/app/shared/services/index.ts
@@ -1,3 +1,4 @@
 // export * from './app-collection.service';
 export * from './collection.service';
 export * from './toast.service';
+export * from './transloco-http.loader';

--- a/src/app/shared/services/transloco-http.loader.ts
+++ b/src/app/shared/services/transloco-http.loader.ts
@@ -1,0 +1,28 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { forkJoin, map, Observable } from 'rxjs';
+import { Translation, TranslocoLoader } from '@jsverse/transloco';
+
+// Build-time generated URLs for all translation files
+const translationUrls = (import.meta as any).glob('../../../assets/i18n/*/*.json', {
+  as: 'url',
+  eager: true,
+});
+
+@Injectable({ providedIn: 'root' })
+export class TranslocoHttpLoader implements TranslocoLoader {
+  private http = inject(HttpClient);
+
+  /**
+   * Loads and merges all JSON translation files for the requested language.
+   */
+  getTranslation(lang: string): Observable<Translation> {
+    const urls = Object.entries(translationUrls)
+      .filter(([path]) => path.includes(`/assets/i18n/${lang}/`))
+      .map(([, url]) => this.http.get<Translation>(url as string));
+
+    return forkJoin(urls).pipe(
+      map((parts) => parts.reduce((acc, curr) => ({ ...acc, ...curr }), {}))
+    );
+  }
+}

--- a/src/assets/i18n/en/agent-edition.json
+++ b/src/assets/i18n/en/agent-edition.json
@@ -1,0 +1,12 @@
+{
+  "FORM": {
+    "TITLE": "Create Agent",
+    "NAME": "Name",
+    "MODEL": "Model",
+    "DESCRIPTION": "Description",
+    "UPLOAD_IMAGE": "Upload Image",
+    "DRAG_DROP": "Drag image here or click to select",
+    "IS_ACTIVE": "Active",
+    "CREATE": "Create Agent"
+  }
+}

--- a/src/assets/i18n/es/agent-edition.json
+++ b/src/assets/i18n/es/agent-edition.json
@@ -1,0 +1,12 @@
+{
+  "FORM": {
+    "TITLE": "Crear Agente",
+    "NAME": "Nombre",
+    "MODEL": "Modelo",
+    "DESCRIPTION": "Descripción",
+    "UPLOAD_IMAGE": "Subir imagen",
+    "DRAG_DROP": "Arrastra la imagen aquí o haz clic para seleccionar",
+    "IS_ACTIVE": "Activo",
+    "CREATE": "Crear Agente"
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,3 +2,4 @@
 
 @use "ng-hub-ui-table/src/lib/styles/table.scss";
 @use "@ng-select/ng-select/themes/default.theme.css";
+@import "@fortawesome/fontawesome-free/css/all.min.css";


### PR DESCRIPTION
## Summary
- add TranslocoHttpLoader to load every translation JSON under assets/i18n
- configure Transloco with custom loader
- skip JWT header for local i18n files
- install Font Awesome and import its styles
- rewrite AgentEditionComponent into a reactive creation form
- add Agent creation endpoint in AgentsService
- provide new i18n keys for agent edition form

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68827f6078c083258ab4d65c10b3f7a4