### PR TITLE
Add knowledge base management

### DIFF
--- a/src/app/private/agent-edition/agent-edition.component.spec.ts
+++ b/src/app/private/agent-edition/agent-edition.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AgentEdition } from './agent-edition';
+import { AgentEditionComponent } from './agent-edition.component';
 
-describe('AgentEdition', () => {
-  let component: AgentEdition;
-  let fixture: ComponentFixture<AgentEdition>;
+describe('AgentEditionComponent', () => {
+  let component: AgentEditionComponent;
+  let fixture: ComponentFixture<AgentEditionComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AgentEdition]
+      imports: [AgentEditionComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(AgentEdition);
+    fixture = TestBed.createComponent(AgentEditionComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/private/knowledge-edition/knowledge-edition.component.html
+++ b/src/app/private/knowledge-edition/knowledge-edition.component.html
@@ -1,0 +1,29 @@
+<div class="container py-4">
+  <h1 class="mb-4">{{ 'KNOWLEDGE_EDITION.TITLES.MAIN' | transloco }}</h1>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" class="vstack gap-3">
+    <div class="mb-3">
+      <label class="form-label">{{ 'KNOWLEDGE_EDITION.FORM.NAME' | transloco }}</label>
+      <input type="text" formControlName="name" class="form-control" />
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">{{ 'KNOWLEDGE_EDITION.FORM.DESCRIPTION' | transloco }}</label>
+      <textarea formControlName="description" class="form-control"></textarea>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Data</label>
+      <textarea formControlName="data" class="form-control" rows="3"></textarea>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Access Control</label>
+      <textarea formControlName="access_control" class="form-control" rows="3"></textarea>
+    </div>
+
+    <button type="submit" class="btn btn-primary">
+      {{ 'KNOWLEDGE_EDITION.FORM.SAVE_BUTTON' | transloco }}
+    </button>
+  </form>
+</div>

--- a/src/app/private/knowledge-edition/knowledge-edition.component.ts
+++ b/src/app/private/knowledge-edition/knowledge-edition.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { Toast } from '../../shared/services/toast.service';
+import { KnowledgeService } from '../knowledge-list/knowledge.service';
+import { KnowledgeBase } from '../knowledge-list/knowledge-base.model';
+
+@Component({
+  selector: 'app-knowledge-edition',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, TranslocoModule, NgSelectModule],
+  templateUrl: './knowledge-edition.component.html',
+})
+export class KnowledgeEditionComponent {
+  fb = inject(FormBuilder);
+  knowledgeSvc = inject(KnowledgeService);
+  transloco = inject(TranslocoService);
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    description: [''],
+    data: this.fb.control<Record<string, any>>({}, { nonNullable: true }),
+    access_control: this.fb.control<Record<string, any>>({}, { nonNullable: true }),
+  });
+
+  constructor() {}
+
+  onSubmit() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.knowledgeSvc.createKnowledge(this.form.value as Partial<KnowledgeBase>).subscribe(() => {
+      Toast.success(this.transloco.translate('KNOWLEDGE_EDITION.FORM.SUCCESS'));
+    });
+  }
+}

--- a/src/app/private/knowledge-list/knowledge-base.model.ts
+++ b/src/app/private/knowledge-list/knowledge-base.model.ts
@@ -1,0 +1,24 @@
+export interface KnowledgeBase {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string;
+  data: Record<string, any>;
+  meta: Record<string, any>;
+  access_control: Record<string, any>;
+  created_at: number;
+  updated_at: number;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+    profile_image_url: string;
+  };
+  files: {
+    id: string;
+    meta: Record<string, any>;
+    created_at: number;
+    updated_at: number;
+  }[];
+}

--- a/src/app/private/knowledge-list/knowledge-list.component.html
+++ b/src/app/private/knowledge-list/knowledge-list.component.html
@@ -1,0 +1,23 @@
+<div class="container-fluid d-flex flex-column gap-4">
+  <h1>{{ 'KNOWLEDGE_LIST.TITLES.MAIN' | transloco }}</h1>
+
+  <div class="d-flex justify-content-end gap-2">
+    <button class="btn btn-primary" [routerLink]="['.', 'create']">
+      {{ 'KNOWLEDGE_LIST.BUTTONS.ADD' | transloco }}
+    </button>
+  </div>
+
+  <hub-ui-table
+    [headers]="headers"
+    [loading]="paginatedData.isLoading()"
+    [data]="paginatedData.value()"
+    [searchable]="false"
+  >
+    <ng-template cellTpt header="created_at" let-property="property">
+      {{ formatDate(property) }}
+    </ng-template>
+    <ng-template noDataTpt>
+      {{ 'KNOWLEDGE_LIST.EMPTY.NO_RESULTS' | transloco }}
+    </ng-template>
+  </hub-ui-table>
+</div>

--- a/src/app/private/knowledge-list/knowledge-list.component.ts
+++ b/src/app/private/knowledge-list/knowledge-list.component.ts
@@ -1,0 +1,50 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  PaginableTableCellDirective,
+  PaginableTableHeader,
+  PaginableTableNotFoundDirective,
+  TableComponent,
+} from 'ng-hub-ui-table';
+import { PaginatedListComponent } from '../../shared/components/paginated-list.component';
+import { KnowledgeBase } from './knowledge-base.model';
+import { KnowledgeService } from './knowledge.service';
+
+@Component({
+  selector: 'app-knowledge-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    TableComponent,
+    PaginableTableCellDirective,
+    PaginableTableNotFoundDirective,
+    RouterLink,
+    TranslocoModule,
+  ],
+  templateUrl: './knowledge-list.component.html',
+})
+export class KnowledgeListComponent extends PaginatedListComponent<KnowledgeBase> {
+  override dataSvc = inject(KnowledgeService);
+
+  override headers: PaginableTableHeader[] = [
+    {
+      title: this.translocoSvc.selectTranslate('KNOWLEDGE_LIST.COLUMNS.NAME'),
+      property: 'name',
+    },
+    {
+      title: this.translocoSvc.selectTranslate('KNOWLEDGE_LIST.COLUMNS.DESCRIPTION'),
+      property: 'description',
+    },
+    {
+      title: this.translocoSvc.selectTranslate('KNOWLEDGE_LIST.COLUMNS.CREATED_AT'),
+      property: 'created_at',
+    },
+  ];
+
+  formatDate(timestamp: number): string {
+    const date = new Date(timestamp);
+    return date.toLocaleDateString();
+  }
+}

--- a/src/app/private/knowledge-list/knowledge.service.ts
+++ b/src/app/private/knowledge-list/knowledge.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { CollectionService } from '../../shared/services';
+import { PagedDataRequestParam } from '../../shared/types/paged-data-request-param';
+import { KnowledgeBase } from './knowledge-base.model';
+
+@Injectable({ providedIn: 'root' })
+export class KnowledgeService extends CollectionService<KnowledgeBase> {
+  protected override path = 'knowledge';
+
+  override list(
+    request: Partial<PagedDataRequestParam> = {}
+  ): Observable<Array<KnowledgeBase>> {
+    return this.http.get<Array<KnowledgeBase>>(
+      `${environment.baseURL}/${this.path}`
+    );
+  }
+
+  createKnowledge(
+    data: Partial<KnowledgeBase>
+  ): Observable<KnowledgeBase> {
+    return this.http.post<KnowledgeBase>(
+      `${environment.baseURL}/${this.path}/create`,
+      data
+    );
+  }
+}

--- a/src/app/private/layout/private-layout.component.html
+++ b/src/app/private/layout/private-layout.component.html
@@ -21,6 +21,11 @@
           <i class="bi bi-people me-2"></i> Agents
         </a>
       </li>
+      <li>
+        <a class="nav-link" routerLink="/private/knowledge" (click)="menuOpen.set(false)">
+          <i class="bi bi-book me-2"></i> Knowledge
+        </a>
+      </li>
     </ul>
   </div>
 </div>
@@ -38,13 +43,18 @@
             <i class="bi bi-speedometer2 me-2"></i> Dashboard
           </a>
         </li>
-        <li>
-          <a class="nav-link" routerLink="/private/agents">
-            <i class="bi bi-people me-2"></i> Agents
-          </a>
-        </li>
-      </ul>
-    </nav>
+      <li>
+        <a class="nav-link" routerLink="/private/agents">
+          <i class="bi bi-people me-2"></i> Agents
+        </a>
+      </li>
+      <li>
+        <a class="nav-link" routerLink="/private/knowledge">
+          <i class="bi bi-book me-2"></i> Knowledge
+        </a>
+      </li>
+    </ul>
+  </nav>
 
     <main class="col-12 col-md-9 ms-sm-auto col-lg-10 px-md-4 pt-3">
       <router-outlet></router-outlet>

--- a/src/app/private/private.routes.ts
+++ b/src/app/private/private.routes.ts
@@ -41,6 +41,25 @@ export const PRIVATE_ROUTES: Routes = [
           },
         ],
       },
+      {
+        path: 'knowledge',
+        children: [
+          {
+            path: '',
+            loadComponent: () =>
+              import('./knowledge-list/knowledge-list.component').then(
+                (c) => c.KnowledgeListComponent
+              ),
+          },
+          {
+            path: 'create',
+            loadComponent: () =>
+              import('./knowledge-edition/knowledge-edition.component').then(
+                (c) => c.KnowledgeEditionComponent
+              ),
+          },
+        ],
+      },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },

--- a/src/assets/i18n/en/knowledge-edition.json
+++ b/src/assets/i18n/en/knowledge-edition.json
@@ -1,0 +1,11 @@
+{
+  "TITLES": {
+    "MAIN": "Knowledge Base"
+  },
+  "FORM": {
+    "NAME": "Name",
+    "DESCRIPTION": "Description",
+    "SAVE_BUTTON": "Save",
+    "SUCCESS": "Knowledge base saved successfully"
+  }
+}

--- a/src/assets/i18n/en/knowledge-list.json
+++ b/src/assets/i18n/en/knowledge-list.json
@@ -1,0 +1,16 @@
+{
+  "TITLES": {
+    "MAIN": "Knowledge Bases"
+  },
+  "COLUMNS": {
+    "NAME": "Name",
+    "DESCRIPTION": "Description",
+    "CREATED_AT": "Created"
+  },
+  "BUTTONS": {
+    "ADD": "Add"
+  },
+  "EMPTY": {
+    "NO_RESULTS": "No knowledge bases found"
+  }
+}

--- a/src/assets/i18n/es/knowledge-edition.json
+++ b/src/assets/i18n/es/knowledge-edition.json
@@ -1,0 +1,11 @@
+{
+  "TITLES": {
+    "MAIN": "Base de Conocimiento"
+  },
+  "FORM": {
+    "NAME": "Nombre",
+    "DESCRIPTION": "Descripción",
+    "SAVE_BUTTON": "Guardar",
+    "SUCCESS": "Base de conocimiento guardada correctamente"
+  }
+}

--- a/src/assets/i18n/es/knowledge-list.json
+++ b/src/assets/i18n/es/knowledge-list.json
@@ -1,0 +1,16 @@
+{
+  "TITLES": {
+    "MAIN": "Bases de Conocimiento"
+  },
+  "COLUMNS": {
+    "NAME": "Nombre",
+    "DESCRIPTION": "Descripción",
+    "CREATED_AT": "Creada"
+  },
+  "BUTTONS": {
+    "ADD": "Añadir"
+  },
+  "EMPTY": {
+    "NO_RESULTS": "No se encontraron bases de conocimiento"
+  }
+}


### PR DESCRIPTION
## Summary
- implement KnowledgeService and createKnowledge method
- add KnowledgeListComponent with paginated table
- add KnowledgeEditionComponent for create form
- register routes and navigation links for knowledge bases
- provide English/Spanish translations for knowledge lists and edition
- fix AgentEditionComponent spec

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_688283ef3980832598f360ada85df419