### PR TITLE
Implement chat UI and service

### DIFF
--- a/src/app/private/agent-chat/agent-chat.component.html
+++ b/src/app/private/agent-chat/agent-chat.component.html
@@ -1,8 +1,31 @@
-<div class="container-fluid d-flex flex-column gap-3">
+<div class="container-fluid d-flex flex-column gap-3" style="height: calc(100vh - 120px);">
   <h1>{{ 'AGENT_CHAT.TITLES.MAIN' }}</h1>
-  <div class="flex-grow-1 border rounded p-3 mb-3" style="min-height: 300px"></div>
-  <div class="mb-3">
-    <input type="text" class="form-control" placeholder="{{ 'AGENT_CHAT.PLACEHOLDER.MESSAGE' }}" />
+  <div class="flex-grow-1 overflow-auto border rounded p-3" #scroll>
+    <div *ngFor="let msg of messages(); let i = index" class="mb-3">
+      <div class="d-flex" [class.justify-content-end]="msg.role === 'user'">
+        <div class="p-2 rounded"
+          [class.bg-primary]="msg.role === 'user'"
+          [class.text-white]="msg.role === 'user'"
+          [class.bg-light]="msg.role === 'assistant'">
+          {{ msg.content }}
+        </div>
+      </div>
+    </div>
+    <div *ngIf="sending()" class="text-muted">{{ 'AGENT_CHAT.STATUS.SENDING' | transloco }}</div>
   </div>
-  <div class="d-flex flex-wrap gap-2"></div>
+
+  @if (messages().length === 0) {
+    <div class="d-flex flex-wrap gap-2">
+      <button class="btn btn-outline-secondary" *ngFor="let s of skills">
+        {{ 'AGENT_CHAT.BUTTONS.' + s }}
+      </button>
+    </div>
+  }
+
+  <div class="input-group">
+    <textarea class="form-control" rows="1" [(ngModel)]="inputValue" [placeholder]="'AGENT_CHAT.INPUT_PLACEHOLDER' | transloco" (keydown.enter)="send(); $event.preventDefault()"></textarea>
+    <button class="btn btn-primary" (click)="send()" [disabled]="sending()">
+      {{ 'AGENT_CHAT.BUTTONS.SEND' | transloco }}
+    </button>
+  </div>
 </div>

--- a/src/app/private/agent-chat/agent-chat.component.ts
+++ b/src/app/private/agent-chat/agent-chat.component.ts
@@ -1,12 +1,67 @@
-
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, ViewChild, inject, WritableSignal, effect } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { TranslocoModule } from '@jsverse/transloco';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { AgentChatService } from './agent-chat.service';
+import { ChatMessage } from './chat-message';
 
+/**
+ * Chat component that mimics the ChatGPT interface.
+ * Messages are displayed above and the input stays fixed at the bottom.
+ */
 @Component({
   selector: 'app-agent-chat',
   standalone: true,
-  imports: [RouterLink, TranslocoModule],
-  templateUrl: './agent-chat.component.html',
+  imports: [CommonModule, FormsModule, RouterLink, TranslocoModule],
+  templateUrl: './agent-chat.component.html'
 })
-export class AgentChatComponent {}
+export class AgentChatComponent {
+  private chatSvc = inject(AgentChatService);
+  transloco = inject(TranslocoService);
+
+  /** Skills available for the agent */
+  skills = [
+    'VISION',
+    'FILE_UPLOAD',
+    'WEB_SEARCH',
+    'IMAGE_GENERATION',
+    'CODE_INTERPRETER',
+    'CITATIONS',
+    'USAGE'
+  ];
+
+  /** Current list of chat messages */
+  messages: WritableSignal<ChatMessage[]> = this.chatSvc.messages;
+  sending = this.chatSvc.sending;
+
+  /** Input model */
+  inputValue = '';
+
+  @ViewChild('scroll') scrollContainer?: ElementRef<HTMLDivElement>;
+
+  constructor() {
+    // Scroll to bottom whenever messages change
+    effect(() => {
+      this.messages();
+      queueMicrotask(() => this.scrollToBottom());
+    });
+  }
+
+  /** Sends the current input value */
+  send(): void {
+    const content = this.inputValue.trim();
+    if (!content) {
+      return;
+    }
+    this.chatSvc.sendMessage('default', content).subscribe();
+    this.inputValue = '';
+  }
+
+  private scrollToBottom(): void {
+    const el = this.scrollContainer?.nativeElement;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+}

--- a/src/app/private/agent-chat/agent-chat.service.ts
+++ b/src/app/private/agent-chat/agent-chat.service.ts
@@ -1,15 +1,59 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { Injectable, WritableSignal, signal, inject } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { CollectionService } from '../../shared/services';
 import { PagedDataRequestParam } from '../../shared/types/paged-data-request-param';
 import { AgentChat } from './agent-chat.model';
+import { ChatMessage } from './chat-message';
 
 @Injectable({ providedIn: 'root' })
 export class AgentChatService extends CollectionService<AgentChat> {
   protected override path = 'chats';
+  /** In-memory message history */
+  readonly messages: WritableSignal<ChatMessage[]> = signal([]);
+
+  /** Flag indicating that a request is in progress */
+  readonly sending = signal(false);
+
+  private http = inject(HttpClient);
 
   override list(request: Partial<PagedDataRequestParam> = {}): Observable<AgentChat[]> {
     return this.http.get<AgentChat[]>(`${environment.baseURL}/${this.path}/`);
+  }
+
+  /** Returns current message history */
+  getMessages(_agentId: string): Observable<ChatMessage[]> {
+    return of(this.messages());
+  }
+
+  /**
+   * Sends a user message to the backend and updates the conversation.
+   * The agent identifier is used as the model name when calling Open WebUI.
+   */
+  sendMessage(agentId: string, content: string): Observable<ChatMessage> {
+    this.sending.set(true);
+    const body = {
+      model: agentId,
+      messages: [...this.messages(), { role: 'user', content }],
+    };
+
+    return this.http
+      .post<{ choices: { message: ChatMessage }[] }>(
+        `${environment.openWebUiUrl}/api/chat/completions`,
+        body
+      )
+      .pipe(
+        map((res) => res.choices[0].message),
+        tap((msg) => {
+          this.messages.update((m) => [...m, { role: 'user', content }, msg]);
+          this.sending.set(false);
+        }),
+        catchError((err) => {
+          this.sending.set(false);
+          throw err;
+        })
+      );
   }
 }

--- a/src/app/private/agent-chat/chat-message.ts
+++ b/src/app/private/agent-chat/chat-message.ts
@@ -1,0 +1,6 @@
+export interface ChatMessage {
+  /** Message role */
+  role: 'system' | 'user' | 'assistant';
+  /** Textual content of the message */
+  content: string;
+}

--- a/src/assets/i18n/en/agent-chat.json
+++ b/src/assets/i18n/en/agent-chat.json
@@ -2,7 +2,18 @@
   "TITLES": {
     "MAIN": "Chat"
   },
-  "PLACEHOLDER": {
-    "MESSAGE": "Type a message"
+  "INPUT_PLACEHOLDER": "Type a message",
+  "BUTTONS": {
+    "VISION": "Vision",
+    "FILE_UPLOAD": "File upload",
+    "WEB_SEARCH": "Web search",
+    "IMAGE_GENERATION": "Image generation",
+    "CODE_INTERPRETER": "Code interpreter",
+    "CITATIONS": "Citations",
+    "USAGE": "Usage",
+    "SEND": "Send"
+  },
+  "STATUS": {
+    "SENDING": "Sending..."
   }
 }

--- a/src/assets/i18n/es/agent-chat.json
+++ b/src/assets/i18n/es/agent-chat.json
@@ -2,7 +2,18 @@
   "TITLES": {
     "MAIN": "Chat"
   },
-  "PLACEHOLDER": {
-    "MESSAGE": "Escribe un mensaje"
+  "INPUT_PLACEHOLDER": "Escribe un mensaje",
+  "BUTTONS": {
+    "VISION": "Visión",
+    "FILE_UPLOAD": "Subir archivo",
+    "WEB_SEARCH": "Búsqueda web",
+    "IMAGE_GENERATION": "Generación de imágenes",
+    "CODE_INTERPRETER": "Intérprete de código",
+    "CITATIONS": "Citas",
+    "USAGE": "Uso",
+    "SEND": "Enviar"
+  },
+  "STATUS": {
+    "SENDING": "Enviando..."
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,4 +2,6 @@ export const environment = {
   name: 'production',
   production: false,
   baseURL: 'https://hackaton.sdilab.es/api/v1',
+  /** Base URL for Open WebUI API */
+  openWebUiUrl: 'http://localhost:8080'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,4 +2,6 @@ export const environment = {
   name: 'development',
   production: false,
   baseURL: 'https://hackaton.sdilab.es/api/v1',
+  /** Base URL for Open WebUI API */
+  openWebUiUrl: 'http://localhost:8080'
 };


### PR DESCRIPTION
## Summary
- enhance translations for chat
- add OpenWebUI URL to environment config
- create chat message model and integrate into service
- implement ChatGPT-like chat component and service

## Testing
- `npm test` *(fails: Could not find the '@angular/build:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_b_6883b96711d88325aed94831d95aab23