### PR TITLE
Implement agent chat flow

### DIFF
--- a/src/app/private/agent-chat/agent-chat.component.html
+++ b/src/app/private/agent-chat/agent-chat.component.html
@@ -23,7 +23,7 @@
   }
 
   <div class="input-group">
-    <textarea class="form-control" rows="1" [(ngModel)]="inputValue" [placeholder]="'AGENT_CHAT.INPUT_PLACEHOLDER' | transloco" (keydown.enter)="send(); $event.preventDefault()"></textarea>
+    <textarea class="form-control" rows="1" [(ngModel)]="inputValue" [placeholder]="'AGENT_CHAT.PLACEHOLDER.INPUT' | transloco" (keydown.enter)="send(); $event.preventDefault()"></textarea>
     <button class="btn btn-primary" (click)="send()" [disabled]="sending()">
       {{ 'AGENT_CHAT.BUTTONS.SEND' | transloco }}
     </button>

--- a/src/app/private/agent-chat/agent-chat.component.ts
+++ b/src/app/private/agent-chat/agent-chat.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, ElementRef, ViewChild, inject, WritableSignal, effect } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { RouterLink, ActivatedRoute } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { AgentChatService } from './agent-chat.service';
 import { ChatMessage } from './chat-message';
@@ -18,6 +18,7 @@ import { ChatMessage } from './chat-message';
 })
 export class AgentChatComponent {
   private chatSvc = inject(AgentChatService);
+  private route = inject(ActivatedRoute);
   transloco = inject(TranslocoService);
 
   /** Skills available for the agent */
@@ -40,6 +41,9 @@ export class AgentChatComponent {
 
   @ViewChild('scroll') scrollContainer?: ElementRef<HTMLDivElement>;
 
+  /** Agent identifier captured from the route */
+  agentId = this.route.snapshot.paramMap.get('agentId') ?? 'default';
+
   constructor() {
     // Scroll to bottom whenever messages change
     effect(() => {
@@ -54,7 +58,13 @@ export class AgentChatComponent {
     if (!content) {
       return;
     }
-    this.chatSvc.sendMessage('default', content).subscribe();
+    if (this.messages().length === 0) {
+      this.chatSvc
+        .createChatWithAgent(this.agentId, content)
+        .catch(() => {});
+    } else {
+      this.chatSvc.sendMessage(this.agentId, content).subscribe();
+    }
     this.inputValue = '';
   }
 

--- a/src/app/private/agent-list/agent-list.component.html
+++ b/src/app/private/agent-list/agent-list.component.html
@@ -36,6 +36,11 @@
         }
       </div>
     </ng-template>
+    <ng-template paginableTableCell header="chat" let-row="row">
+      <a [routerLink]="['/agents', row.id, 'chat']" class="btn btn-link p-0">
+        {{ 'AGENT_CHAT.NEW_BUTTON' | transloco }}
+      </a>
+    </ng-template>
 
     <ng-template noDataTpt>
       {{ "AGENT_LIST.EMPTY.NO_RESULTS" }}

--- a/src/app/private/agent-list/agent-list.component.ts
+++ b/src/app/private/agent-list/agent-list.component.ts
@@ -50,6 +50,7 @@ export class AgentListComponent extends PaginatedListComponent<Agent> {
       title: this.translocoSvc.selectTranslate('AGENT_LIST.COLUMNS.FEATURES'),
       property: 'meta.capabilities',
     },
+    { title: '', property: 'chat', sortable: false },
   ];
 
   /**

--- a/src/app/private/private.routes.ts
+++ b/src/app/private/private.routes.ts
@@ -33,6 +33,13 @@ export const PRIVATE_ROUTES: Routes = [
               ),
           },
           {
+            path: ':agentId/chat',
+            loadComponent: () =>
+              import('./agent-chat/agent-chat.component').then(
+                (c) => c.AgentChatComponent
+              ),
+          },
+          {
             path: ':id',
             loadComponent: () =>
               import('./agent-edition/agent-edition.component').then(

--- a/src/assets/i18n/en/agent-chat.json
+++ b/src/assets/i18n/en/agent-chat.json
@@ -2,7 +2,9 @@
   "TITLES": {
     "MAIN": "Chat"
   },
-  "INPUT_PLACEHOLDER": "Type a message",
+  "PLACEHOLDER": {
+    "INPUT": "Type a message"
+  },
   "BUTTONS": {
     "VISION": "Vision",
     "FILE_UPLOAD": "File upload",
@@ -15,5 +17,6 @@
   },
   "STATUS": {
     "SENDING": "Sending..."
-  }
+  },
+  "NEW_BUTTON": "New Chat"
 }

--- a/src/assets/i18n/es/agent-chat.json
+++ b/src/assets/i18n/es/agent-chat.json
@@ -2,7 +2,9 @@
   "TITLES": {
     "MAIN": "Chat"
   },
-  "INPUT_PLACEHOLDER": "Escribe un mensaje",
+  "PLACEHOLDER": {
+    "INPUT": "Escribe un mensaje"
+  },
   "BUTTONS": {
     "VISION": "Visión",
     "FILE_UPLOAD": "Subir archivo",
@@ -15,5 +17,6 @@
   },
   "STATUS": {
     "SENDING": "Enviando..."
-  }
+  },
+  "NEW_BUTTON": "Nuevo chat"
 }


### PR DESCRIPTION
## Summary
- allow starting a chat from agent list
- capture `agentId` from route and create chat
- integrate with Open WebUI API
- update translations and UI placeholders

## Testing
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6883c43033fc83258bf9dbdb7b3e9fea