### PR TITLE
Implement chat history loading and auto scroll

### DIFF
--- a/src/app/private/agent-chat/agent-chat.component.html
+++ b/src/app/private/agent-chat/agent-chat.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid d-flex flex-column gap-3 vh-100">
   <h1>{{ "AGENT_CHAT.TITLES.MAIN" }}</h1>
-  <div class="flex-grow-1 overflow-auto border rounded p-3" #scroll>
+  <div class="flex-grow-1 overflow-auto border rounded p-3" #scrollContainer>
     <div *ngFor="let msg of messages(); let i = index" class="mb-3">
       <div class="d-flex" [class.justify-content-end]="msg.role === 'user'">
         <div
@@ -13,17 +13,23 @@
         </div>
       </div>
     </div>
+    <div *ngIf="loading()" class="text-muted">
+      {{ "AGENT_CHAT.STATUS.LOADING" }}
+    </div>
+    <div *ngIf="error()" class="text-danger">
+      {{ "AGENT_CHAT.STATUS.ERROR" }}
+    </div>
     <div *ngIf="sending()" class="text-muted">
       {{ "AGENT_CHAT.STATUS.SENDING" }}
     </div>
   </div>
 
   @if (messages().length === 0) {
-  <div class="d-flex flex-wrap gap-2">
-    <button class="btn btn-outline-secondary" *ngFor="let s of skills">
-      {{ "AGENT_CHAT.BUTTONS." + s }}
-    </button>
-  </div>
+    <div class="d-flex flex-wrap gap-2">
+      <button class="btn btn-outline-secondary" *ngFor="let s of skills">
+        {{ "AGENT_CHAT.BUTTONS." + s }}
+      </button>
+    </div>
   }
 
   <div class="input-group mt-2 sticky-bottom bg-white">
@@ -31,7 +37,7 @@
       class="form-control"
       rows="1"
       [(ngModel)]="inputValue"
-      [placeholder]="'AGENT_CHAT.PLACEHOLDER.INPUT'"
+      [placeholder]="'AGENT_CHAT.PLACEHOLDER.INPUT' | transloco"
       (keydown.enter)="send(); $event.preventDefault()"
     ></textarea>
     <button class="btn btn-primary" (click)="send()" [disabled]="sending()">

--- a/src/assets/i18n/en/agent-chat.json
+++ b/src/assets/i18n/en/agent-chat.json
@@ -16,7 +16,9 @@
     "SEND": "Send"
   },
   "STATUS": {
-    "SENDING": "Sending..."
+    "SENDING": "Sending...",
+    "LOADING": "Loading conversation...",
+    "ERROR": "Unable to load conversation"
   },
   "NEW_BUTTON": "New Chat"
 }

--- a/src/assets/i18n/es/agent-chat.json
+++ b/src/assets/i18n/es/agent-chat.json
@@ -16,7 +16,9 @@
     "SEND": "Enviar"
   },
   "STATUS": {
-    "SENDING": "Enviando..."
+    "SENDING": "Enviando...",
+    "LOADING": "Cargando conversaci\u00f3n...",
+    "ERROR": "No se pudo cargar la conversaci\u00f3n"
   },
   "NEW_BUTTON": "Nuevo chat"
 }


### PR DESCRIPTION
## Summary
- fetch existing chat history on navigation using chatId
- add loading and error signals to AgentChatComponent
- auto scroll when new messages render
- internationalize placeholder and status messages

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883e2b5e92c83259b4b50e842f2f128