### PR TITLE
Implement user profile display

### DIFF
--- a/public/i18n/ast.json
+++ b/public/i18n/ast.json
@@ -231,6 +231,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -231,6 +231,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -233,6 +233,14 @@
       "MAIN": "User Profile"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "My profile",
+    "NAME": "Name",
+    "EMAIL": "Email",
+    "ROLE": "Role",
+    "LANGUAGE": "Preferred language",
+    "EDIT_BUTTON": "Edit profile"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Dashboard",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -233,6 +233,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -231,6 +231,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -231,6 +231,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/public/i18n/oc.json
+++ b/public/i18n/oc.json
@@ -231,6 +231,14 @@
       "MAIN": "Perfil de usuario"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "Mi perfil",
+    "NAME": "Nombre",
+    "EMAIL": "Correo electrónico",
+    "ROLE": "Rol",
+    "LANGUAGE": "Idioma preferido",
+    "EDIT_BUTTON": "Editar perfil"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Panel",

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -27,6 +27,8 @@ interface CurrentUser {
   name: string;
   email: string;
   avatar?: string;
+  role?: string;
+  language?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -39,6 +41,8 @@ export class AuthService {
     name: string;
     email: string;
     avatar?: string;
+    role?: string;
+    language?: string;
   } | null>(JSON.parse(localStorage.getItem('user') || 'null'));
 
   readonly user = this._user.asReadonly();
@@ -99,7 +103,17 @@ export class AuthService {
     localStorage.setItem('language', lang);
   }
 
-  setUser(user: { name: string; email: string; avatar?: string } | null): void {
+  setUser(
+    user:
+      | {
+          name: string;
+          email: string;
+          avatar?: string;
+          role?: string;
+          language?: string;
+        }
+      | null
+  ): void {
     this._user.set(user);
     if (user) {
       localStorage.setItem('user', JSON.stringify(user));

--- a/src/app/auth/resolvers/user.resolver.ts
+++ b/src/app/auth/resolvers/user.resolver.ts
@@ -15,6 +15,7 @@ export class UserResolver implements Resolve<any | null> {
       this.authSvc.logout();
       return null;
     }
+    this.authSvc.setUser(user);
     return user;
   }
 }

--- a/src/app/private/user-profile/user-profile.component.ts
+++ b/src/app/private/user-profile/user-profile.component.ts
@@ -1,10 +1,52 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
+import { AvatarComponent } from 'ng-hub-ui-avatar';
+import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'app-user-profile',
   standalone: true,
-  imports: [TranslocoModule],
-  template: `<div class="container py-4"><h1>{{ 'PROFILE.TITLES.MAIN' | transloco }}</h1></div>`
+  imports: [TranslocoModule, AvatarComponent],
+  template: `
+    <div class="container py-4">
+      <h1>{{ 'USER_PROFILE.TITLE' | transloco }}</h1>
+      <div class="row justify-content-center">
+        <div class="col-md-6">
+          <div class="card text-center">
+            <div class="card-body">
+              <hub-avatar
+                [name]="user()?.name"
+                [src]="user()?.avatar"
+                size="120"
+              ></hub-avatar>
+              <h5 class="card-title mt-3">{{ user()?.name }}</h5>
+              <p class="mb-1">
+                <strong>{{ 'USER_PROFILE.EMAIL' | transloco }}:</strong>
+                {{ user()?.email }}
+              </p>
+              @if (user()?.role) {
+                <p class="mb-1">
+                  <strong>{{ 'USER_PROFILE.ROLE' | transloco }}:</strong>
+                  {{ user()?.role }}
+                </p>
+              }
+              @if (user()?.language) {
+                <p class="mb-1">
+                  <strong>{{ 'USER_PROFILE.LANGUAGE' | transloco }}:</strong>
+                  {{ user()?.language }}
+                </p>
+              }
+              <button class="btn btn-primary mt-3">
+                {{ 'USER_PROFILE.EDIT_BUTTON' | transloco }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
 })
-export class UserProfileComponent {}
+export class UserProfileComponent {
+  auth = inject(AuthService);
+  user = this.auth.user;
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -239,6 +239,14 @@
       "MAIN": "User Profile"
     }
   },
+  "USER_PROFILE": {
+    "TITLE": "My profile",
+    "NAME": "Name",
+    "EMAIL": "Email",
+    "ROLE": "Role",
+    "LANGUAGE": "Preferred language",
+    "EDIT_BUTTON": "Edit profile"
+  },
   "SIDEBAR": {
     "MENU": {
       "DASHBOARD": "Dashboard",


### PR DESCRIPTION
## Summary
- extend `AuthService` user model with role and language
- save user data in `UserResolver`
- create profile card with user details
- add translations for USER_PROFILE screen in all languages

## Testing
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_6884f2211ba88325bfe089b189db070c