### PR TITLE
Add responsive dashboard home

### DIFF
--- a/src/app/private/home/dashboard.service.ts
+++ b/src/app/private/home/dashboard.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface DashboardChat {
+  id: string;
+  title: string;
+  agentName: string;
+  updatedAt: number;
+  active?: boolean;
+  avatar?: string;
+}
+
+export interface DashboardAgent {
+  id: string;
+  name: string;
+  avatar?: string;
+  type: 'global' | 'personal';
+}
+
+@Injectable({ providedIn: 'root' })
+export class DashboardService {
+  chats = signal<DashboardChat[]>([
+    {
+      id: '1',
+      title: 'Ejemplo de conversación',
+      agentName: 'Agente Uno',
+      updatedAt: Date.now() - 3600 * 1000,
+      active: true,
+    },
+    {
+      id: '2',
+      title: 'Consulta sobre ventas',
+      agentName: 'Agente Dos',
+      updatedAt: Date.now() - 86400 * 1000,
+    },
+  ]);
+
+  agents = signal<DashboardAgent[]>([
+    {
+      id: '1',
+      name: 'Agente Uno',
+      type: 'global',
+    },
+    {
+      id: '2',
+      name: 'Agente Dos',
+      type: 'personal',
+    },
+  ]);
+}

--- a/src/app/private/home/home.component.html
+++ b/src/app/private/home/home.component.html
@@ -1,8 +1,88 @@
-<div class="vh-100 w-100 p-0 m-0">
-  <iframe
-    src="https://sdidigitalgroup.sharepoint.com/sites/VivaHome"
-    title="Greenfield Home"
-    class="border-0 w-100 h-100"
-    >{{ "HOME.IFRAME_FALLBACK" | transloco }}</iframe
-  >
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-12 mb-4">
+      <h1 class="fw-bold fs-4 mb-1">{{ 'DASHBOARD.TITLE' | transloco }}</h1>
+      <p class="mb-3">{{ 'DASHBOARD.SUBTITLE' | transloco }}</p>
+      <input
+        type="text"
+        class="form-control mb-4 w-100"
+        [placeholder]="'DASHBOARD.SEARCH.PLACEHOLDER' | transloco"
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-8">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h5 mb-0">{{ 'DASHBOARD.RECENT_CONVERSATIONS' | transloco }}</h2>
+        <button class="btn btn-sm btn-light border">
+          {{ 'DASHBOARD.SEE_ALL' | transloco }}
+        </button>
+      </div>
+      @for (chat of chats(); track chat.id) {
+      <div
+        class="card p-3 mb-3 shadow-sm chat"
+        role="button"
+        (click)="openChat(chat.id)"
+      >
+        <div class="d-flex align-items-center">
+          <div class="me-3">
+            <img
+              *ngIf="chat.avatar"
+              [src]="chat.avatar"
+              class="rounded-circle"
+              width="40"
+              height="40"
+            />
+          </div>
+          <div class="flex-grow-1">
+            <div class="fw-bold">{{ chat.title }}</div>
+            <small class="text-muted">{{ chat.agentName }}</small>
+            @if (chat.active) {
+            <span class="badge bg-success ms-2">Activa</span>
+            }
+          </div>
+          <div class="ms-auto text-nowrap small text-muted">
+            {{ timeAgo(chat.updatedAt) }}
+          </div>
+        </div>
+      </div>
+      }
+    </div>
+    <div class="col-12 col-lg-4">
+      <div class="mb-4">
+        <h2 class="h6">{{ 'DASHBOARD.QUICK_ACTIONS.TITLE' | transloco }}</h2>
+        <button class="btn btn-success btn-sm w-100 text-start mb-2" (click)="openNewAgent()">
+          {{ 'DASHBOARD.QUICK_ACTIONS.NEW_AGENT' | transloco }}
+        </button>
+        <button class="btn btn-outline-secondary btn-sm w-100 text-start mb-2" (click)="exploreMarketplace()">
+          {{ 'DASHBOARD.QUICK_ACTIONS.EXPLORE_MARKETPLACE' | transloco }}
+        </button>
+        <button class="btn btn-outline-secondary btn-sm w-100 text-start mb-2" (click)="viewFavorites()">
+          {{ 'DASHBOARD.QUICK_ACTIONS.FAVORITES' | transloco }}
+        </button>
+      </div>
+      <div>
+        <h2 class="h6">{{ 'DASHBOARD.AVAILABLE_AGENTS.TITLE' | transloco }}</h2>
+        @for (ag of agents(); track ag.id) {
+        <div
+          class="card p-2 mb-2 d-flex align-items-center agent"
+          role="button"
+          (click)="openAgent(ag.id)"
+        >
+          <img
+            *ngIf="ag.avatar"
+            [src]="ag.avatar"
+            class="rounded-circle me-2"
+            width="32"
+            height="32"
+          />
+          <div class="flex-grow-1">
+            <span class="fw-bold">{{ ag.name }}</span>
+          </div>
+          <span class="badge bg-secondary text-capitalize">{{ ag.type }}</span>
+        </div>
+        }
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/private/home/home.component.ts
+++ b/src/app/private/home/home.component.ts
@@ -1,10 +1,51 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
+import { DashboardService } from './dashboard.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [TranslocoModule],
+  imports: [CommonModule, TranslocoModule, RouterLink],
   templateUrl: './home.component.html',
 })
-export class HomeComponent {}
+export class HomeComponent {
+  private dashboard = inject(DashboardService);
+  private router = inject(Router);
+
+  chats = this.dashboard.chats;
+  agents = this.dashboard.agents;
+
+  openChat(id: string): void {
+    this.router.navigate(['/private/chats', id]);
+  }
+
+  openAgent(id: string): void {
+    this.router.navigate(['/private/agents', id]);
+  }
+
+  openNewAgent(): void {
+    this.router.navigate(['/private/agents', 'add']);
+  }
+
+  exploreMarketplace(): void {
+    // placeholder for future action
+  }
+
+  viewFavorites(): void {
+    // placeholder for future action
+  }
+
+  timeAgo(timestamp: number): string {
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return 'Hace segundos';
+    if (minutes < 60) return `Hace ${minutes} min`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `Hace ${hours} h`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `Hace ${days} d`;
+    return new Date(timestamp).toLocaleDateString();
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -150,28 +150,21 @@
     }
   },
   "DASHBOARD": {
-    "TITLES": {
-      "MAIN": "Dashboard"
+    "TITLE": "¡Bienvenido de vuelta!",
+    "SUBTITLE": "Continúa trabajando con tus agentes o explora nuevas posibilidades.",
+    "SEARCH": {
+      "PLACEHOLDER": "Buscar agentes, conversaciones o tareas…"
     },
-    "SECTIONS": {
-      "QUICK_ACCESS": "Quick Access",
-      "RECENT_ACTIVITY": "Recent Activity"
+    "RECENT_CONVERSATIONS": "Conversaciones Recientes",
+    "SEE_ALL": "Ver todas",
+    "QUICK_ACTIONS": {
+      "TITLE": "Acciones Rápidas",
+      "NEW_AGENT": "Crear nuevo agente",
+      "EXPLORE_MARKETPLACE": "Explorar Marketplace",
+      "FAVORITES": "Ver favoritos"
     },
-    "METRICS": {
-      "TRAININGS_COMPLETED": "Trainings completed",
-      "DOCUMENTS_INDEXED": "Indexed documents",
-      "AVERAGE_SCORE": "Average score",
-      "ACTIVE_AGENTS": "Active agents"
-    },
-    "ACTIONS": {
-      "NEW_DOC": "New document",
-      "NEW_AGENT": "Create agent",
-      "RUN_TRAINING": "Launch training"
-    },
-    "LOGS": {
-      "USER_CREATED_AGENT": "User Juan created an agent",
-      "DOC_INDEXED": "Document Manual.pdf indexed",
-      "TRAINING_UPDATED": "Basic training updated"
+    "AVAILABLE_AGENTS": {
+      "TITLE": "Agentes Disponibles"
     }
   },
   "EVALUATION": {


### PR DESCRIPTION
## Summary
- replace home page with responsive dashboard
- mock chat and agent data in DashboardService
- add quick actions and recent items
- provide dashboard translations

## Testing
- `npx -y -p @angular/cli ng test --watch=false` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_68860196ebe88325bd47a333cffa2772