### PR TITLE
Refactor private layout and new sidebar

### DIFF
--- a/public/i18n/ast.json
+++ b/public/i18n/ast.json
@@ -260,4 +260,22 @@
       "MAIN": "Formación"
     }
   }
+,
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
+  }
 }

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -260,4 +260,22 @@
       "MAIN": "Formación"
     }
   }
+,
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
+  }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -272,7 +272,24 @@
   "NOT_FOUND": {
     "MESSAGE": "The page you are looking for does not exist"
   },
-  "HOME": {
+  "HOME":{
     "IFRAME_FALLBACK": "Your browser cannot display the content"
+  },
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu":{
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -271,8 +271,24 @@
   },
   "NOT_FOUND": {
     "MESSAGE": "La página que buscas no existe"
-  },
-  "HOME": {
+  },"HOME":{
     "IFRAME_FALLBACK": "Tu navegador no permite mostrar el contenido"
+  },
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
   }
 }

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -260,4 +260,22 @@
       "MAIN": "Formación"
     }
   }
+,
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
+  }
 }

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -260,4 +260,22 @@
       "MAIN": "Formación"
     }
   }
+,
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
+  }
 }

--- a/public/i18n/oc.json
+++ b/public/i18n/oc.json
@@ -260,4 +260,22 @@
       "MAIN": "Formación"
     }
   }
+,
+  "sidebar": {
+    "home": "Inicio",
+    "myAgents": "Mis Agentes",
+    "chats": "Chats",
+    "createNewAgent": "Crear nuevo agente",
+    "marketplace": "Marketplace",
+    "evaluation": "Evaluación IA",
+    "training": "Formación",
+    "gamification": "Gamificación",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "userMenu": {
+      "profile": "Perfil de usuario",
+      "language": "Cambiar idioma",
+      "logout": "Cerrar sesión"
+    }
+  }
 }

--- a/src/app/private/layout/aside/aside.component.html
+++ b/src/app/private/layout/aside/aside.component.html
@@ -1,0 +1,133 @@
+<aside class="sidebar d-flex flex-column h-100">
+  <div class="sidebar-header flex-shrink-0">
+    <a routerLink="/" class="text-decoration-none fw-semibold fs-4">
+      Greenfield<span class="text-success">&bull;</span>
+    </a>
+  </div>
+
+  <div class="sidebar-body flex-grow-1 overflow-y-auto">
+    <button
+      class="btn btn-outline-success btn-sm w-100 mb-3"
+      style="border-style: dashed;"
+      routerLink="/private/agents/add"
+      (click)="navigate.emit()"
+    >
+      <i class="bi bi-plus"></i>
+      {{ 'sidebar.createNewAgent' | transloco }}
+    </button>
+
+    <ul class="nav flex-column">
+      <li *ngFor="let item of menuItems" class="mb-1">
+        <ng-container [ngSwitch]="item.id">
+          <ng-container *ngSwitchCase="'chats'">
+            <div class="collapsible-section">
+              <button
+                class="btn btn-link text-start w-100 d-flex align-items-center justify-content-between"
+                (click)="toggleChatsCollapse()"
+              >
+                <div class="d-flex align-items-center">
+                  <i class="bi bi-{{ item.icon }} me-2"></i>
+                  <span>{{ item.label | transloco }}</span>
+                </div>
+                <i class="bi" [class.bi-chevron-down]="!chatsCollapsed()" [class.bi-chevron-right]="chatsCollapsed()"></i>
+              </button>
+              <div class="collapse" [class.show]="!chatsCollapsed()">
+                <div class="pinned-chats-container">
+                  <a
+                    *ngFor="let chat of pinnedChats(); track chat.id"
+                    [routerLink]="['/chats', chat.id]"
+                    class="pinned-chat-item d-flex align-items-center p-2 text-decoration-none"
+                    (click)="navigate.emit()"
+                  >
+                    <div class="chat-avatar me-2">
+                      <i class="bi bi-chat-fill"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                      <div class="chat-title">{{ chat.title }}</div>
+                      <div class="chat-preview text-muted small">{{ chat.lastMessage }}</div>
+                    </div>
+                    <span *ngIf="chat.unreadCount" class="badge bg-primary rounded-pill">{{ chat.unreadCount }}</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </ng-container>
+          <ng-container *ngSwitchDefault>
+            <a
+              *ngIf="!item.isCollapsible"
+              [routerLink]="item.route"
+              routerLinkActive="nav-item-active"
+              class="nav-link d-flex align-items-center"
+              (click)="navigate.emit()"
+            >
+              <i class="bi bi-{{ item.icon }} me-2"></i>
+              <span>{{ item.label | transloco }}</span>
+            </a>
+            <div *ngIf="item.isCollapsible" class="collapsible-section">
+              <button
+                class="btn btn-link text-start w-100 d-flex align-items-center justify-content-between"
+                (click)="toggleAgentsCollapse()"
+              >
+                <div class="d-flex align-items-center">
+                  <i class="bi bi-{{ item.icon }} me-2"></i>
+                  <span>{{ item.label | transloco }}</span>
+                </div>
+                <i class="bi" [class.bi-chevron-down]="!agentsCollapsed()" [class.bi-chevron-right]="agentsCollapsed()"></i>
+              </button>
+              <div class="collapse" [class.show]="!agentsCollapsed()"></div>
+            </div>
+          </ng-container>
+        </ng-container>
+      </li>
+    </ul>
+  </div>
+
+  <div class="sidebar-footer flex-shrink-0 p-2">
+    <div class="dropdown dropup w-100">
+      <button class="btn btn-link text-start w-100 d-flex align-items-center p-3" data-bs-toggle="dropdown">
+        <img [src]="currentUser()?.avatar" class="rounded-circle me-2" width="32" height="32" />
+        <div class="flex-grow-1 text-start">
+          <div class="fw-semibold">{{ currentUser()?.name }}</div>
+          <div class="text-muted small">{{ currentUser()?.email }}</div>
+        </div>
+        <i class="bi bi-three-dots-vertical"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end w-100">
+        <li>
+          <a class="dropdown-item" routerLink="/profile" (click)="navigate.emit()">
+            <i class="bi bi-person me-2"></i>
+            {{ 'sidebar.userMenu.profile' | transloco }}
+          </a>
+        </li>
+        <li>
+          <div class="dropdown-item-text">
+            <div class="dropdown dropend w-100">
+              <button class="btn btn-link text-start w-100 p-0 d-flex align-items-center justify-content-between" data-bs-toggle="dropdown">
+                <span>
+                  <i class="bi bi-globe me-2"></i>
+                  {{ 'sidebar.userMenu.language' | transloco }}
+                </span>
+                <i class="bi bi-chevron-right"></i>
+              </button>
+              <ul class="dropdown-menu">
+                <li *ngFor="let lang of languages">
+                  <button class="dropdown-item" (click)="changeLanguage(lang.code)">
+                    <span class="fi fi-{{ lang.code }} me-2"></span>
+                    {{ lang.labelKey | transloco }}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li><hr class="dropdown-divider" /></li>
+        <li>
+          <button class="dropdown-item text-danger" (click)="logout()">
+            <i class="bi bi-box-arrow-right me-2"></i>
+            {{ 'sidebar.userMenu.logout' | transloco }}
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</aside>

--- a/src/app/private/layout/aside/aside.component.scss
+++ b/src/app/private/layout/aside/aside.component.scss
@@ -1,0 +1,57 @@
+.sidebar {
+  width: var(--bs-sidebar-width, 280px);
+  background-color: var(--bs-body-bg);
+  border-right: var(--bs-border-width) solid var(--bs-border-color);
+
+  .sidebar-header {
+    padding: var(--bs-spacer-3);
+    border-bottom: var(--bs-border-width) solid var(--bs-border-color-translucent);
+  }
+
+  .sidebar-body {
+    padding: var(--bs-spacer-2) var(--bs-spacer-3);
+  }
+
+  .sidebar-footer {
+    border-top: var(--bs-border-width) solid var(--bs-border-color-translucent);
+    background-color: var(--bs-gray-50);
+  }
+
+  .nav-item-active {
+    background-color: var(--bs-success);
+    color: var(--bs-white);
+    border-radius: var(--bs-border-radius);
+  }
+
+  .collapsible-section {
+    margin-bottom: var(--bs-spacer-2);
+  }
+
+  .pinned-chat-item {
+    border-radius: var(--bs-border-radius-sm);
+    transition: background-color 0.15s ease-in-out;
+
+    &:hover {
+      background-color: var(--bs-gray-100);
+    }
+
+    .chat-title {
+      font-size: var(--bs-font-size-sm);
+      font-weight: var(--bs-font-weight-medium);
+    }
+
+    .chat-preview {
+      font-size: var(--bs-font-size-xs);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 150px;
+    }
+  }
+}
+
+@media (max-width: 767.98px) {
+  .sidebar {
+    width: 100%;
+  }
+}

--- a/src/app/private/layout/aside/aside.component.ts
+++ b/src/app/private/layout/aside/aside.component.ts
@@ -1,0 +1,75 @@
+import { Component, EventEmitter, Output, inject, signal } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { NgFor, NgIf } from '@angular/common';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { AvatarComponent } from 'ng-hub-ui-avatar';
+import { AuthService } from '../../../auth/auth.service';
+import { LANGUAGES } from '../../../shared/constants/languages';
+import { ChatService } from '../chat.service';
+
+interface MenuItem {
+  id: string;
+  label: string;
+  icon: string;
+  route?: string;
+  isActive?: boolean;
+  isCollapsible?: boolean;
+  children?: MenuItem[];
+}
+
+const MENU_ITEMS: MenuItem[] = [
+  { id: 'home', label: 'sidebar.home', icon: 'house', route: '/private/home', isActive: true },
+  { id: 'agents', label: 'sidebar.myAgents', icon: 'person', isCollapsible: true, children: [] },
+  { id: 'chats', label: 'sidebar.chats', icon: 'chat', isCollapsible: true, children: [] },
+  { id: 'marketplace', label: 'sidebar.marketplace', icon: 'cart', route: '/marketplace' },
+  { id: 'evaluation', label: 'sidebar.evaluation', icon: 'clock', route: '/evaluation' },
+  { id: 'training', label: 'sidebar.training', icon: 'mortarboard', route: '/training' },
+  { id: 'gamification', label: 'sidebar.gamification', icon: 'trophy', route: '/gamification' },
+  { id: 'settings', label: 'sidebar.settings', icon: 'gear', route: '/settings' },
+  { id: 'help', label: 'sidebar.help', icon: 'question-circle', route: '/help' },
+];
+
+@Component({
+  selector: 'app-aside',
+  standalone: true,
+  imports: [NgFor, NgIf, RouterLink, RouterLinkActive, TranslocoModule, AvatarComponent],
+  templateUrl: './aside.component.html',
+  styleUrls: ['./aside.component.scss'],
+})
+export class AsideComponent {
+  @Output() navigate = new EventEmitter<void>();
+
+  auth = inject(AuthService);
+  transloco = inject(TranslocoService);
+  chatSvc = inject(ChatService);
+
+  languages = LANGUAGES;
+  currentLang = signal(localStorage.getItem('language') || 'es');
+
+  menuItems = MENU_ITEMS;
+
+  agentsCollapsed = signal(true);
+  chatsCollapsed = signal(true);
+
+  pinnedChats = this.chatSvc.pinnedChats;
+
+  changeLanguage(lang: string) {
+    this.currentLang.set(lang);
+    this.transloco.setActiveLang(lang);
+    localStorage.setItem('language', lang);
+  }
+
+  toggleAgentsCollapse() {
+    this.agentsCollapsed.update((v) => !v);
+  }
+
+  toggleChatsCollapse() {
+    this.chatsCollapsed.update((v) => !v);
+  }
+
+  logout() {
+    this.auth.logout();
+  }
+
+  currentUser = this.auth.user;
+}

--- a/src/app/private/layout/chat.service.ts
+++ b/src/app/private/layout/chat.service.ts
@@ -1,0 +1,17 @@
+import { firstValueFrom } from "rxjs";
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject, resource } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { PinnedChat } from './pinned-chat';
+
+@Injectable({ providedIn: 'root' })
+export class ChatService {
+  private http = inject(HttpClient);
+
+  private pinnedChatsResource = resource({
+    loader: () => firstValueFrom(this.http.get<PinnedChat[]>(`${environment.baseURL}/chats/pinned`)),
+  });
+
+  readonly pinnedChats = this.pinnedChatsResource.value;
+  readonly isLoadingPinned = this.pinnedChatsResource.isLoading;
+}

--- a/src/app/private/layout/pinned-chat.ts
+++ b/src/app/private/layout/pinned-chat.ts
@@ -1,0 +1,7 @@
+export interface PinnedChat {
+  id: string;
+  title: string;
+  lastMessage?: string;
+  lastActivity: Date;
+  unreadCount?: number;
+}

--- a/src/app/private/layout/private-layout.component.html
+++ b/src/app/private/layout/private-layout.component.html
@@ -1,253 +1,26 @@
-<!-- Toggle button visible on small screens -->
-<button class="btn btn-light d-md-none m-2" (click)="menuOpen.set(true)">
-  <i class="fa fa-bars"></i>
+<!-- Toggle button for offcanvas menu -->
+<button class="btn btn-light d-md-none m-2" (click)="toggleMenu()">
+  <i class="bi bi-list"></i>
 </button>
 
-<!-- Offcanvas menu for mobile -->
-<div class="offcanvas offcanvas-start" [class.show]="menuOpen()" tabindex="-1">
+<!-- Offcanvas for mobile -->
+<div class="offcanvas offcanvas-start" [class.show]="menuOpen()" tabindex="-1" style="visibility: {{ menuOpen() ? 'visible' : 'hidden' }};">
   <div class="offcanvas-header">
-    <h5 class="offcanvas-title">{{ "SIDEBAR.MENU.TITLE" | transloco }}</h5>
-    <button
-      type="button"
-      class="btn-close"
-      (click)="menuOpen.set(false)"
-    ></button>
+    <button type="button" class="btn-close" (click)="toggleMenu()"></button>
   </div>
   <div class="offcanvas-body p-0">
-    <div class="text-center py-3 border-bottom">
-      <a routerLink="/home" class="text-decoration-none">
-        <span class="fw-bold fs-4">Greenfield</span>
-      </a>
-    </div>
-    <ul class="nav nav-pills flex-column mb-auto">
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          routerLink="/private/home"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-house me-2"></i>
-          {{ "SIDEBAR.MENU.HOME" | transloco }}
-        </a>
-      </li>
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          routerLink="/private/intranet"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-house me-2"></i>
-          {{ "SIDEBAR.MENU.INTRANET" | transloco }}
-        </a>
-      </li>
-      <li>
-        <a
-          class="nav-link"
-          routerLink="/private/evaluation"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-clipboard-check me-2"></i>
-          {{ "SIDEBAR.MENU.EVALUATION" | transloco }}
-        </a>
-      </li>
-      <li>
-        <a
-          class="nav-link"
-          routerLink="/private/training"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-book-open me-2"></i>
-          {{ "SIDEBAR.MENU.TRAINING" | transloco }}
-        </a>
-      </li>
-      <li>
-        <a
-          class="nav-link"
-          routerLink="/private/agents"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-brain me-2"></i>
-          {{ "SIDEBAR.MENU.AGENTS" | transloco }}
-        </a>
-        @if (pinnedSvc.pinned().length) {
-        <ul class="nav flex-column ms-3">
-          @for (ag of pinnedSvc.pinned(); track ag) {
-          <li class="nav-item">
-            <a
-              class="nav-link"
-              [routerLink]="['/private/agents', ag.id]"
-              (click)="menuOpen.set(false)"
-              >{{ ag.name }}</a
-            >
-          </li>
-          }
-        </ul>
-        }
-      </li>
-
-      <li>
-        <a
-          class="nav-link"
-          routerLink="/private/chats"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-comments me-2"></i>
-          {{ "SIDEBAR.MENU.CHATS" | transloco }}
-        </a>
-      </li>
-      <li>
-        <a class="nav-link" href="#" (click)="menuOpen.set(false)">
-          <i class="fa fa-file-alt me-2"></i>
-          {{ "SIDEBAR.MENU.DOCUMENTATION" | transloco }}
-        </a>
-      </li>
-      <li>
-        <a
-          class="nav-link"
-          routerLink="/private/knowledge-bases"
-          (click)="menuOpen.set(false)"
-        >
-          <i class="fa fa-folder me-2"></i>
-          {{ "SIDEBAR.MENU.KNOWLEDGE" | transloco }}
-        </a>
-      </li>
-    </ul>
-    <div class="mt-3 border-top pt-3 text-center">
-      <a
-        routerLink="/profile"
-        class="text-decoration-none d-block"
-        (click)="menuOpen.set(false)"
-      >
-        <hub-avatar
-          [name]="user()?.name"
-          [src]="user()?.avatar"
-          size="40"
-        ></hub-avatar>
-        <div class="small">{{ user()?.name }}</div>
-        <div class="text-muted small">{{ user()?.email }}</div>
-      </a>
-      <select
-        class="form-select mt-2"
-        [ngModel]="currentLang()"
-        (ngModelChange)="changeLang($event)"
-      >
-        @for (l of languages; track l) {
-        <option [value]="l.code">{{ l.labelKey | transloco }}</option>
-        }
-      </select>
-      <button class="btn btn-link mt-2" (click)="logout()">
-        <i class="fa fa-sign-out-alt"></i>
-        {{ "SIDEBAR.ACTIONS.LOGOUT" | transloco }}
-      </button>
-    </div>
+    <app-aside (navigate)="toggleMenu()"></app-aside>
   </div>
 </div>
 @if (menuOpen()) {
-<div
-  class="offcanvas-backdrop fade show d-md-none"
-  (click)="menuOpen.set(false)"
-></div>
+  <div class="offcanvas-backdrop fade show d-md-none" (click)="toggleMenu()"></div>
 }
 
-<div class="container-fluid">
-  <div class="row">
-    <!-- Static sidebar for md and above -->
-    <nav class="col-md-3 col-lg-2 d-none d-md-block bg-light p-3 min-vh-100">
-      <div class="text-center pb-3 mb-2 border-bottom">
-        <a routerLink="/home" class="text-decoration-none">
-          <span class="fw-bold fs-4">Greenfield</span>
-        </a>
-      </div>
-      <ul class="nav nav-pills flex-column mb-auto">
-        <li class="nav-item">
-          <a class="nav-link" routerLink="/private/home">
-            <i class="fa fa-house me-2"></i>
-            {{ "SIDEBAR.MENU.HOME" | transloco }}
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" routerLink="/private/intranet">
-            <i class="fa fa-house me-2"></i>
-            {{ "SIDEBAR.MENU.INTRANET" | transloco }}
-          </a>
-        </li>
-        <li>
-          <a class="nav-link" routerLink="/private/evaluation">
-            <i class="fa fa-clipboard-check me-2"></i>
-            {{ "SIDEBAR.MENU.EVALUATION" | transloco }}
-          </a>
-        </li>
-        <li>
-          <a class="nav-link" routerLink="/private/training">
-            <i class="fa fa-book-open me-2"></i>
-            {{ "SIDEBAR.MENU.TRAINING" | transloco }}
-          </a>
-        </li>
-        <li>
-          <a class="nav-link" routerLink="/private/agents">
-            <i class="fa fa-brain me-2"></i>
-            {{ "SIDEBAR.MENU.AGENTS" | transloco }}
-          </a>
-          @if (pinnedSvc.pinned().length) {
-          <ul class="nav flex-column ms-3">
-            @for (ag of pinnedSvc.pinned(); track ag) {
-            <li class="nav-item">
-              <a class="nav-link" [routerLink]="['/private/agents', ag.id]">{{
-                ag.name
-              }}</a>
-            </li>
-            }
-          </ul>
-          }
-        </li>
-
-        <li>
-          <a class="nav-link" routerLink="/private/chats">
-            <i class="fa fa-comments me-2"></i>
-            {{ "SIDEBAR.MENU.CHATS" | transloco }}
-          </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#">
-            <i class="fa fa-file-alt me-2"></i>
-            {{ "SIDEBAR.MENU.DOCUMENTATION" | transloco }}
-          </a>
-        </li>
-        <li>
-          <a class="nav-link" routerLink="/private/knowledge-bases">
-            <i class="fa fa-folder me-2"></i>
-            {{ "SIDEBAR.MENU.KNOWLEDGE" | transloco }}
-          </a>
-        </li>
-        <div class="mt-3 border-top pt-3 text-center">
-          <a routerLink="/private/profile" class="text-decoration-none d-block">
-            <hub-avatar
-              [name]="user()?.name"
-              [src]="user()?.avatar"
-              size="40"
-            ></hub-avatar>
-            <div class="small">{{ user()?.name }}</div>
-            <div class="text-muted small">{{ user()?.email }}</div>
-          </a>
-          <select
-            class="form-select mt-2"
-            [ngModel]="currentLang()"
-            (ngModelChange)="changeLang($event)"
-          >
-            @for (l of languages; track l) {
-            <option [value]="l.code">{{ l.labelKey | transloco }}</option>
-            }
-          </select>
-          <button class="btn btn-link mt-2" (click)="logout()">
-            <i class="fa fa-sign-out-alt"></i>
-            {{ "SIDEBAR.ACTIONS.LOGOUT" | transloco }}
-          </button>
-        </div>
-      </ul>
-    </nav>
-
-    <main class="col-12 col-md-9 ms-sm-auto col-lg-10 px-md-4 pt-3">
-      <router-outlet></router-outlet>
-    </main>
+<div class="private-layout">
+  <div class="aside-container d-none d-md-block">
+    <app-aside></app-aside>
+  </div>
+  <div class="main-content">
+    <router-outlet></router-outlet>
   </div>
 </div>

--- a/src/app/private/layout/private-layout.component.scss
+++ b/src/app/private/layout/private-layout.component.scss
@@ -1,0 +1,29 @@
+.private-layout {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+
+  .aside-container {
+    flex-shrink: 0;
+    height: 100vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .main-content {
+    flex: 1;
+    height: 100vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+}
+
+.offcanvas {
+  height: 100vh;
+
+  .offcanvas-body {
+    height: calc(100vh - 60px);
+    overflow-y: auto;
+    padding: 0;
+  }
+}

--- a/src/app/private/layout/private-layout.component.ts
+++ b/src/app/private/layout/private-layout.component.ts
@@ -1,44 +1,18 @@
 import { Component, inject, signal } from '@angular/core';
-import { PinnedAgentsService } from '../../shared/services';
-import { AuthService } from '../../auth/auth.service';
-import { RouterLink, RouterOutlet } from '@angular/router';
-import { FormsModule } from '@angular/forms';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { AvatarComponent } from 'ng-hub-ui-avatar';
-import { LANGUAGES } from '../../shared/constants';
+import { RouterOutlet } from '@angular/router';
+import { AsideComponent } from './aside/aside.component';
 
 @Component({
   selector: 'app-private-layout',
   standalone: true,
-  imports: [RouterLink, RouterOutlet, FormsModule, TranslocoModule, AvatarComponent],
-  templateUrl: './private-layout.component.html'
+  imports: [AsideComponent, RouterOutlet],
+  templateUrl: './private-layout.component.html',
+  styleUrls: ['./private-layout.component.scss']
 })
 export class PrivateLayoutComponent {
-  /** Controls offcanvas visibility on small screens */
   menuOpen = signal(false);
 
-  pinnedSvc = inject(PinnedAgentsService);
-  auth = inject(AuthService);
-  transloco = inject(TranslocoService);
-
-  /** Available languages list */
-  languages = LANGUAGES;
-  /** Current active language */
-  currentLang = signal(localStorage.getItem('language') || 'es');
-
-  user = this.auth.user;
-
-  constructor() {
-    this.transloco.setActiveLang(this.currentLang());
-  }
-
-  changeLang(lang: string) {
-    this.currentLang.set(lang);
-    this.transloco.setActiveLang(lang);
-    localStorage.setItem('language', lang);
-  }
-
-  logout(): void {
-    this.auth.logout();
+  toggleMenu() {
+    this.menuOpen.update(v => !v);
   }
 }


### PR DESCRIPTION
## Summary
- redesign private layout with flex 100vh height and offcanvas menu
- add aside component with collapsible chats and user dropdown
- implement service to load pinned chats
- update translations with new sidebar strings

## Testing
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68866f4295a4832595f9171b6bb7d71e