### PR TITLE
Implement new translation structure and aside improvements

### DIFF
--- a/src/app/private/knowledge-base/file-upload.component.ts
+++ b/src/app/private/knowledge-base/file-upload.component.ts
@@ -24,7 +24,7 @@ interface FileUploadItem {
       (click)="fileInput.click()"
     >
       <p class="m-0">
-        {{ 'fileUpload.dragDropText' | transloco }}
+        {{ 'FILEUPLOAD.LABELS.DRAG_DROP' | transloco }}
       </p>
       <input
         type="file"
@@ -46,11 +46,11 @@ interface FileUploadItem {
       </div>
       } @if (item.status === 'completed') {
       <div class="alert-success">
-        {{ item.file.name }} - {{ 'fileUpload.success' | transloco }}
+        {{ item.file.name }} - {{ 'FILEUPLOAD.MESSAGES.SUCCESS' | transloco }}
       </div>
       } @if (item.status === 'error') {
       <div class="alert-danger">
-        {{ item.file.name }} - {{ 'fileUpload.error' | transloco }}
+        {{ item.file.name }} - {{ 'FILEUPLOAD.MESSAGES.ERROR' | transloco }}
       </div>
       }
     </div>

--- a/src/app/private/knowledge-base/knowledge-base-detail.component.html
+++ b/src/app/private/knowledge-base/knowledge-base-detail.component.html
@@ -7,7 +7,7 @@
       [routerLink]="['/private/knowledge-bases', kb.id, 'edit']"
     >
       <i class="bi bi-pencil"></i>
-      {{ "knowledgeBase.editButton" | transloco }}
+      {{ 'KNOWLEDGEBASEDETAIL.BUTTONS.EDIT' | transloco }}
     </a>
   </div>
   <p>{{ kb.description }}</p>
@@ -22,7 +22,7 @@
       </div>
     </div>
     } @empty {
-    <p>{{ "knowledgeBase.noFiles" | transloco }}</p>
+    <p>{{ 'KNOWLEDGEBASEDETAIL.MESSAGES.NO_FILES' | transloco }}</p>
     }
   </div>
 </div>

--- a/src/app/private/knowledge-base/knowledge-base-edition.component.html
+++ b/src/app/private/knowledge-base/knowledge-base-edition.component.html
@@ -7,9 +7,9 @@
         type="text"
         formControlName="name"
         class="form-control"
-        placeholder="{{ 'knowledgeBase.name' | transloco }}"
+        placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.NAME' | transloco }}"
       />
-      <label for="name">{{ "knowledgeBase.name" | transloco }}</label>
+      <label for="name">{{ 'KNOWLEDGEBASEEDITION.LABELS.NAME' | transloco }}</label>
     </div>
 
     <div class="form-floating mb-3">
@@ -18,27 +18,31 @@
         formControlName="description"
         class="form-control"
         style="height: 120px"
-        placeholder="{{ 'knowledgeBase.description' | transloco }}"
+        placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.DESCRIPTION' | transloco }}"
       ></textarea>
-      <label for="description">{{
-        "knowledgeBase.description" | transloco
-      }}</label>
+      <label for="description">
+        {{ 'KNOWLEDGEBASEEDITION.LABELS.DESCRIPTION' | transloco }}
+      </label>
     </div>
 
     <div class="mb-3">
-      <label class="form-label">{{
-        "knowledgeBase.visibility" | transloco
-      }}</label>
+      <label class="form-label">
+        {{ 'KNOWLEDGEBASEEDITION.LABELS.VISIBILITY' | transloco }}
+      </label>
       <select formControlName="visibility" class="form-select">
-        <option value="private">{{ "visibility.private" | transloco }}</option>
+        <option value="private">
+          {{ 'KNOWLEDGEBASEEDITION.LABELS.PRIVATE' | transloco }}
+        </option>
       </select>
       <div class="form-text">
-        {{ "visibility.privateDesc" | transloco }}
+        {{ 'KNOWLEDGEBASEEDITION.MESSAGES.PRIVATE_DESC' | transloco }}
       </div>
     </div>
 
     <div class="mb-3">
-      <label class="form-label">{{ "knowledgeBase.groups" | transloco }}</label>
+      <label class="form-label">
+        {{ 'KNOWLEDGEBASEEDITION.LABELS.GROUPS' | transloco }}
+      </label>
       <ng-select
         [items]="groups.value()"
         [loading]="groups.isLoading()"
@@ -46,12 +50,12 @@
         bindLabel="name"
         bindValue="id"
         [multiple]="true"
-        placeholder="{{ 'knowledgeBase.groups' | transloco }}"
+        placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.SELECT_GROUP' | transloco }}"
         formControlName="groups"
       ></ng-select>
       @if (!groups.value()?.length) {
       <div class="form-text">
-        No hay grupos con acceso, añade un grupo para otorgar acceso
+        {{ 'KNOWLEDGEBASEEDITION.MESSAGES.NO_GROUPS' | transloco }}
       </div>
       }
     </div>
@@ -59,8 +63,8 @@
     <button type="submit" class="btn btn-primary btn-lg w-100">
       {{
         isEditMode()
-          ? ("knowledgeBase.saveButton" | transloco)
-          : ("knowledgeBase.saveButton" | transloco)
+          ? ('KNOWLEDGEBASEEDITION.BUTTONS.UPDATE' | transloco)
+          : ('KNOWLEDGEBASEEDITION.BUTTONS.CREATE' | transloco)
       }}
     </button>
   </form>

--- a/src/app/private/knowledge-base/knowledge-base-edition.component.ts
+++ b/src/app/private/knowledge-base/knowledge-base-edition.component.ts
@@ -59,8 +59,8 @@ export class KnowledgeBaseEditionComponent {
   readonly isEditMode = computed(() => !!this.knowledgeBaseId());
   readonly formTitle = computed(() =>
     this.isEditMode()
-      ? this.#transloco.translate('knowledgeBase.edit')
-      : this.#transloco.translate('knowledgeBase.create')
+      ? this.#transloco.translate('KNOWLEDGEBASEEDITION.TITLES.EDIT')
+      : this.#transloco.translate('KNOWLEDGEBASEEDITION.TITLES.CREATE')
   );
 
   submit() {

--- a/src/app/private/knowledge-list/knowledge-list.component.html
+++ b/src/app/private/knowledge-list/knowledge-list.component.html
@@ -1,9 +1,9 @@
 <div class="container-fluid d-flex flex-column gap-4">
-  <h1>{{ "KNOWLEDGE_LIST.TITLES.MAIN" | transloco }}</h1>
+  <h1>{{ 'KNOWLEDGEBASELIST.TITLES.MAIN' | transloco }}</h1>
 
   <div class="d-flex justify-content-end gap-2">
     <button class="btn btn-primary" [routerLink]="['.', 'add']">
-      {{ "KNOWLEDGE_LIST.BUTTONS.ADD" | transloco }}
+      {{ 'KNOWLEDGEBASELIST.BUTTONS.ADD' | transloco }}
     </button>
   </div>
 
@@ -25,7 +25,7 @@
       {{ formatDate(property) }}
     </ng-template>
     <ng-template noDataTpt>
-      {{ "KNOWLEDGE_LIST.EMPTY.NO_RESULTS" | transloco }}
+      {{ 'KNOWLEDGEBASELIST.EMPTY.NO_RESULTS' | transloco }}
     </ng-template>
   </hub-ui-table>
 </div>

--- a/src/app/private/knowledge-list/knowledge-list.component.ts
+++ b/src/app/private/knowledge-list/knowledge-list.component.ts
@@ -28,18 +28,18 @@ export class KnowledgeListComponent extends PaginatedListComponent<KnowledgeBase
 
   override headers: PaginableTableHeader[] = [
     {
-      title: this.translocoSvc.selectTranslate('KNOWLEDGE_LIST.COLUMNS.NAME'),
+      title: this.translocoSvc.selectTranslate('KNOWLEDGEBASELIST.COLUMNS.NAME'),
       property: 'name',
     },
     {
       title: this.translocoSvc.selectTranslate(
-        'KNOWLEDGE_LIST.COLUMNS.DESCRIPTION'
+        'KNOWLEDGEBASELIST.COLUMNS.DESCRIPTION'
       ),
       property: 'description',
     },
     {
       title: this.translocoSvc.selectTranslate(
-        'KNOWLEDGE_LIST.COLUMNS.CREATED_AT'
+        'KNOWLEDGEBASELIST.COLUMNS.CREATED_AT'
       ),
       property: 'created_at',
     },

--- a/src/app/private/layout/aside/aside.component.html
+++ b/src/app/private/layout/aside/aside.component.html
@@ -11,79 +11,64 @@
       style="border-style: dashed;"
       routerLink="/private/agents/add"
       (click)="navigate.emit()"
-      >
+    >
       <i class="bi bi-plus"></i>
-      {{ 'sidebar.createNewAgent' | transloco }}
+      {{ 'ASIDE.BUTTONS.CREATE_NEW_AGENT' | transloco }}
     </button>
 
     <ul class="nav flex-column">
-      @for (item of menuItems; track item) {
+      @for (item of menuItems; track item.id) {
         <li class="mb-1">
-          @switch (item.id) {
-            @case ('chats') {
-              <div class="collapsible-section">
-                <button
-                  class="btn btn-link text-start w-100 d-flex align-items-center justify-content-between"
-                  (click)="toggleChatsCollapse()"
-                  >
-                  <div class="d-flex align-items-center">
-                    <i class="bi bi-{{ item.icon }} me-2"></i>
-                    <span>{{ item.label | transloco }}</span>
-                  </div>
-                  <i class="bi" [class.bi-chevron-down]="!chatsCollapsed()" [class.bi-chevron-right]="chatsCollapsed()"></i>
-                </button>
-                <div class="collapse" [class.show]="!chatsCollapsed()">
-                  <div class="pinned-chats-container">
-                    @for (chat of pinnedChats(); track chat) {
-                      <a
-                        [routerLink]="['/chats', chat.id]"
-                        class="pinned-chat-item d-flex align-items-center p-2 text-decoration-none"
-                        (click)="navigate.emit()"
-                        >
-                        <div class="chat-avatar me-2">
-                          <i class="bi bi-chat-fill"></i>
-                        </div>
-                        <div class="flex-grow-1">
-                          <div class="chat-title">{{ chat.title }}</div>
-                          <div class="chat-preview text-muted small">{{ chat.lastMessage }}</div>
-                        </div>
-                        @if (chat.unreadCount) {
-                          <span class="badge bg-primary rounded-pill">{{ chat.unreadCount }}</span>
-                        }
-                      </a>
-                    }
-                  </div>
-                </div>
-              </div>
-            }
-            @default {
-              @if (!item.isCollapsible) {
-                <a
-                  [routerLink]="item.route"
-                  routerLinkActive="nav-item-active"
-                  class="nav-link d-flex align-items-center"
-                  (click)="navigate.emit()"
-                  >
+          @if (item.id === 'chats') {
+            <div class="collapsible-section">
+              <button
+                class="btn btn-link text-start w-100 d-flex align-items-center justify-content-between"
+                (click)="toggleChatsCollapse()"
+              >
+                <div class="d-flex align-items-center">
                   <i class="bi bi-{{ item.icon }} me-2"></i>
                   <span>{{ item.label | transloco }}</span>
-                </a>
-              }
-              @if (item.isCollapsible) {
-                <div class="collapsible-section">
-                  <button
-                    class="btn btn-link text-start w-100 d-flex align-items-center justify-content-between"
-                    (click)="toggleAgentsCollapse()"
-                    >
-                    <div class="d-flex align-items-center">
-                      <i class="bi bi-{{ item.icon }} me-2"></i>
-                      <span>{{ item.label | transloco }}</span>
-                    </div>
-                    <i class="bi" [class.bi-chevron-down]="!agentsCollapsed()" [class.bi-chevron-right]="agentsCollapsed()"></i>
-                  </button>
-                  <div class="collapse" [class.show]="!agentsCollapsed()"></div>
                 </div>
-              }
-            }
+                <i
+                  class="bi"
+                  [class.bi-chevron-down]="!chatsCollapsed()"
+                  [class.bi-chevron-right]="chatsCollapsed()"
+                ></i>
+              </button>
+              <div class="collapse" [class.show]="!chatsCollapsed()">
+                <div class="pinned-chats-container">
+                  @for (chat of pinnedChats(); track chat) {
+                    <a
+                      [routerLink]="['/chats', chat.id]"
+                      class="pinned-chat-item d-flex align-items-center p-2 text-decoration-none"
+                      (click)="navigate.emit()"
+                    >
+                      <div class="chat-avatar me-2">
+                        <i class="bi bi-chat-fill"></i>
+                      </div>
+                      <div class="flex-grow-1">
+                        <div class="chat-title">{{ chat.title }}</div>
+                        <div class="chat-preview text-muted small">{{ chat.lastMessage }}</div>
+                      </div>
+                      @if (chat.unreadCount) {
+                        <span class="badge bg-primary rounded-pill">{{ chat.unreadCount }}</span>
+                      }
+                    </a>
+                  }
+                </div>
+              </div>
+            </div>
+          } @else {
+            <a
+              class="nav-link d-flex align-items-center py-2 px-3 rounded"
+              [routerLink]="item.route"
+              routerLinkActive="nav-item-active"
+              [routerLinkActiveOptions]="{ exact: item.id === 'home' }"
+              (click)="navigate.emit()"
+            >
+              <i class="bi bi-{{ item.icon }} me-3"></i>
+              <span>{{ item.label | transloco }}</span>
+            </a>
           }
         </li>
       }
@@ -93,36 +78,55 @@
   <div class="sidebar-footer flex-shrink-0 p-2">
     <div class="dropdown dropup w-100">
       <button class="btn btn-link text-start w-100 d-flex align-items-center p-3" data-bs-toggle="dropdown">
-        <img [src]="currentUser()?.avatar" class="rounded-circle me-2" width="32" height="32" />
+        <img
+          [src]="currentUser()?.avatar || '/assets/images/default-avatar.png'"
+          class="rounded-circle me-2"
+          width="32"
+          height="32"
+          [alt]="currentUser()?.name"
+        />
         <div class="flex-grow-1 text-start">
-          <div class="fw-semibold">{{ currentUser()?.name }}</div>
-          <div class="text-muted small">{{ currentUser()?.email }}</div>
+          <div class="fw-semibold text-truncate">{{ currentUser()?.name }}</div>
+          <div class="text-muted small text-truncate">{{ currentUser()?.email }}</div>
         </div>
         <i class="bi bi-three-dots-vertical"></i>
       </button>
-      <ul class="dropdown-menu dropdown-menu-end w-100">
+      <ul class="dropdown-menu dropdown-menu-end w-100 shadow" aria-labelledby="userDropdown">
         <li>
-          <a class="dropdown-item" routerLink="/profile" (click)="navigate.emit()">
+          <a class="dropdown-item d-flex align-items-center" routerLink="/profile" (click)="navigate.emit()">
             <i class="bi bi-person me-2"></i>
-            {{ 'sidebar.userMenu.profile' | transloco }}
+            {{ 'ASIDE.BUTTONS.PROFILE' | transloco }}
           </a>
         </li>
         <li>
-          <div class="dropdown-item-text">
+          <div class="dropdown-item p-0">
             <div class="dropdown dropend w-100">
-              <button class="btn btn-link text-start w-100 p-0 d-flex align-items-center justify-content-between" data-bs-toggle="dropdown">
-                <span>
+              <button
+                class="btn btn-link text-start w-100 p-3 border-0 d-flex align-items-center justify-content-between"
+                type="button"
+                id="languageDropdown"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+              >
+                <span class="d-flex align-items-center">
                   <i class="bi bi-globe me-2"></i>
-                  {{ 'sidebar.userMenu.language' | transloco }}
+                  {{ 'ASIDE.BUTTONS.CHANGE_LANGUAGE' | transloco }}
                 </span>
                 <i class="bi bi-chevron-right"></i>
               </button>
-              <ul class="dropdown-menu">
-                @for (lang of languages; track lang) {
+              <ul class="dropdown-menu shadow" aria-labelledby="languageDropdown">
+                @for (lang of languages; track lang.code) {
                   <li>
-                    <button class="dropdown-item" (click)="changeLanguage(lang.code)">
+                    <button
+                      class="dropdown-item d-flex align-items-center"
+                      (click)="changeLanguage(lang.code)"
+                      [class.active]="currentLang() === lang.code"
+                    >
                       <span class="fi fi-{{ lang.code }} me-2"></span>
                       {{ lang.labelKey | transloco }}
+                      @if (currentLang() === lang.code) {
+                        <i class="bi bi-check ms-auto"></i>
+                      }
                     </button>
                   </li>
                 }
@@ -132,9 +136,9 @@
         </li>
         <li><hr class="dropdown-divider" /></li>
         <li>
-          <button class="dropdown-item text-danger" (click)="logout()">
+          <button class="dropdown-item text-danger d-flex align-items-center" (click)="logout()">
             <i class="bi bi-box-arrow-right me-2"></i>
-            {{ 'sidebar.userMenu.logout' | transloco }}
+            {{ 'ASIDE.BUTTONS.LOGOUT' | transloco }}
           </button>
         </li>
       </ul>

--- a/src/app/private/layout/aside/aside.component.scss
+++ b/src/app/private/layout/aside/aside.component.scss
@@ -18,9 +18,27 @@
   }
 
   .nav-item-active {
-    background-color: var(--bs-success);
-    color: var(--bs-white);
-    border-radius: var(--bs-border-radius);
+    background-color: var(--bs-success) !important;
+    color: var(--bs-white) !important;
+
+    i {
+      color: var(--bs-white) !important;
+    }
+  }
+
+  .nav-link {
+    color: var(--bs-gray-700);
+    transition: all 0.2s ease-in-out;
+
+    &:hover:not(.nav-item-active) {
+      background-color: var(--bs-gray-100);
+      color: var(--bs-gray-900);
+    }
+
+    i {
+      color: var(--bs-gray-600);
+      transition: color 0.2s ease-in-out;
+    }
   }
 
   .collapsible-section {

--- a/src/app/private/layout/aside/aside.component.ts
+++ b/src/app/private/layout/aside/aside.component.ts
@@ -1,5 +1,13 @@
-import { Component, EventEmitter, Output, inject, signal } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Output,
+  inject,
+  signal,
+  afterNextRender,
+} from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+import * as bootstrap from 'bootstrap';
 
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { AvatarComponent } from 'ng-hub-ui-avatar';
@@ -12,21 +20,72 @@ interface MenuItem {
   label: string;
   icon: string;
   route?: string;
-  isActive?: boolean;
   isCollapsible?: boolean;
   children?: MenuItem[];
 }
 
 const MENU_ITEMS: MenuItem[] = [
-  { id: 'home', label: 'sidebar.home', icon: 'house', route: '/private/home', isActive: true },
-  { id: 'agents', label: 'sidebar.myAgents', icon: 'person', isCollapsible: true, children: [] },
-  { id: 'chats', label: 'sidebar.chats', icon: 'chat', isCollapsible: true, children: [] },
-  { id: 'marketplace', label: 'sidebar.marketplace', icon: 'cart', route: '/marketplace' },
-  { id: 'evaluation', label: 'sidebar.evaluation', icon: 'clock', route: '/evaluation' },
-  { id: 'training', label: 'sidebar.training', icon: 'mortarboard', route: '/training' },
-  { id: 'gamification', label: 'sidebar.gamification', icon: 'trophy', route: '/gamification' },
-  { id: 'settings', label: 'sidebar.settings', icon: 'gear', route: '/settings' },
-  { id: 'help', label: 'sidebar.help', icon: 'question-circle', route: '/help' },
+  {
+    id: 'home',
+    label: 'ASIDE.LABELS.HOME',
+    icon: 'house',
+    route: '/private/home',
+  },
+  {
+    id: 'intranet',
+    label: 'ASIDE.LABELS.INTRANET',
+    icon: 'building',
+    route: '/private/intranet',
+  },
+  {
+    id: 'agents',
+    label: 'ASIDE.LABELS.MY_AGENTS',
+    icon: 'person',
+    route: '/private/agents',
+  },
+  {
+    id: 'chats',
+    label: 'ASIDE.LABELS.CHATS',
+    icon: 'chat',
+    isCollapsible: true,
+    children: [],
+  },
+  {
+    id: 'marketplace',
+    label: 'ASIDE.LABELS.MARKETPLACE',
+    icon: 'cart',
+    route: '/marketplace',
+  },
+  {
+    id: 'evaluation',
+    label: 'ASIDE.LABELS.EVALUATION',
+    icon: 'clock',
+    route: '/evaluation',
+  },
+  {
+    id: 'training',
+    label: 'ASIDE.LABELS.TRAINING',
+    icon: 'mortarboard',
+    route: '/training',
+  },
+  {
+    id: 'gamification',
+    label: 'ASIDE.LABELS.GAMIFICATION',
+    icon: 'trophy',
+    route: '/gamification',
+  },
+  {
+    id: 'settings',
+    label: 'ASIDE.LABELS.SETTINGS',
+    icon: 'gear',
+    route: '/settings',
+  },
+  {
+    id: 'help',
+    label: 'ASIDE.LABELS.HELP',
+    icon: 'question-circle',
+    route: '/help',
+  },
 ];
 
 @Component({
@@ -48,19 +107,25 @@ export class AsideComponent {
 
   menuItems = MENU_ITEMS;
 
-  agentsCollapsed = signal(true);
   chatsCollapsed = signal(true);
 
   pinnedChats = this.chatSvc.pinnedChats;
+
+  constructor() {
+    afterNextRender(() => {
+      const dropdownElements = document.querySelectorAll(
+        '[data-bs-toggle="dropdown"]'
+      );
+      dropdownElements.forEach((el) => {
+        new bootstrap.Dropdown(el);
+      });
+    });
+  }
 
   changeLanguage(lang: string) {
     this.currentLang.set(lang);
     this.transloco.setActiveLang(lang);
     localStorage.setItem('language', lang);
-  }
-
-  toggleAgentsCollapse() {
-    this.agentsCollapsed.update((v) => !v);
   }
 
   toggleChatsCollapse() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -317,4 +317,126 @@
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
   }
+  ,
+  "ASIDE": {
+    "LABELS": {
+      "HOME": "Home",
+      "INTRANET": "Intranet",
+      "MY_AGENTS": "My Agents",
+      "CHATS": "Chats",
+      "MARKETPLACE": "Marketplace",
+      "EVALUATION": "AI Evaluation",
+      "TRAINING": "Training",
+      "GAMIFICATION": "Gamification",
+      "SETTINGS": "Settings",
+      "HELP": "Help"
+    },
+    "BUTTONS": {
+      "CREATE_NEW_AGENT": "Create new agent",
+      "PROFILE": "User profile",
+      "CHANGE_LANGUAGE": "Change language",
+      "LOGOUT": "Logout"
+    }
+  },
+  "KNOWLEDGEBASEEDITION": {
+    "TITLES": {
+      "CREATE": "Create Knowledge Base",
+      "EDIT": "Edit Knowledge Base"
+    },
+    "LABELS": {
+      "NAME": "Name",
+      "DESCRIPTION": "Description",
+      "VISIBILITY": "Visibility",
+      "GROUPS": "Groups",
+      "PRIVATE": "Private",
+      "PUBLIC": "Public",
+      "RESTRICTED": "Restricted"
+    },
+    "PLACEHOLDERS": {
+      "NAME": "Name your knowledge base",
+      "DESCRIPTION": "Describe your Knowledge Base and its goals",
+      "SELECT_GROUP": "Select a group"
+    },
+    "BUTTONS": {
+      "CREATE": "Create Knowledge",
+      "UPDATE": "Update Knowledge",
+      "CANCEL": "Cancel"
+    },
+    "MESSAGES": {
+      "NO_GROUPS": "No groups have access, add a group to grant access",
+      "PRIVATE_DESC": "Only allowed users and groups can access",
+      "CREATE_SUCCESS": "Knowledge base created successfully",
+      "UPDATE_SUCCESS": "Knowledge base updated successfully",
+      "CREATE_ERROR": "Error creating knowledge base",
+      "UPDATE_ERROR": "Error updating knowledge base"
+    }
+  },
+  "KNOWLEDGEBASEDETAIL": {
+    "TITLES": {
+      "DETAIL": "Knowledge Base Detail",
+      "FILES": "Associated Files"
+    },
+    "LABELS": {
+      "NAME": "Name",
+      "DESCRIPTION": "Description",
+      "VISIBILITY": "Visibility",
+      "GROUPS": "Groups",
+      "CREATED_AT": "Created at",
+      "UPDATED_AT": "Last update"
+    },
+    "BUTTONS": {
+      "EDIT": "Edit",
+      "DELETE": "Delete",
+      "ADD_FILES": "Add Files",
+      "DOWNLOAD": "Download",
+      "REMOVE_FILE": "Remove file"
+    },
+    "MESSAGES": {
+      "NO_FILES": "No files associated",
+      "DELETE_CONFIRM": "Are you sure you want to delete this knowledge base?",
+      "DELETE_SUCCESS": "Knowledge base deleted successfully",
+      "DELETE_ERROR": "Error deleting knowledge base"
+    }
+  },
+  "FILEUPLOAD": {
+    "TITLES": {
+      "UPLOAD_FILES": "Upload Files"
+    },
+    "LABELS": {
+      "DRAG_DROP": "Drag files here or click to select",
+      "SELECTED_FILES": "Selected files",
+      "UPLOAD_PROGRESS": "Upload progress"
+    },
+    "BUTTONS": {
+      "SELECT_FILES": "Select files",
+      "UPLOAD": "Upload",
+      "CANCEL": "Cancel",
+      "REMOVE": "Remove"
+    },
+    "MESSAGES": {
+      "UPLOADING": "Uploading...",
+      "ASSOCIATING": "Associating file...",
+      "SUCCESS": "File uploaded successfully",
+      "ERROR": "Error uploading file",
+      "INVALID_TYPE": "File type not allowed",
+      "MAX_SIZE": "File too large",
+      "UPLOAD_COMPLETE": "All files were uploaded successfully"
+    }
+  },
+  "KNOWLEDGEBASELIST": {
+    "TITLES": {
+      "MAIN": "Knowledge Bases"
+    },
+    "COLUMNS": {
+      "NAME": "Name",
+      "DESCRIPTION": "Description",
+      "CREATED_AT": "Created"
+    },
+    "BUTTONS": {
+      "ADD": "Add"
+    },
+    "EMPTY": {
+      "NO_RESULTS": "No knowledge bases found"
+    }
+  }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -317,4 +317,126 @@
     "restricted": "Restringido",
     "privateDesc": "Solo pueden acceder los usuarios y grupos con permiso"
   }
+  ,
+  "ASIDE": {
+    "LABELS": {
+      "HOME": "Inicio",
+      "INTRANET": "Intranet",
+      "MY_AGENTS": "Mis Agentes",
+      "CHATS": "Chats",
+      "MARKETPLACE": "Marketplace",
+      "EVALUATION": "Evaluación IA",
+      "TRAINING": "Formación",
+      "GAMIFICATION": "Gamificación",
+      "SETTINGS": "Configuración",
+      "HELP": "Ayuda"
+    },
+    "BUTTONS": {
+      "CREATE_NEW_AGENT": "Crear nuevo agente",
+      "PROFILE": "Perfil de usuario",
+      "CHANGE_LANGUAGE": "Cambiar idioma",
+      "LOGOUT": "Cerrar sesión"
+    }
+  },
+  "KNOWLEDGEBASEEDITION": {
+    "TITLES": {
+      "CREATE": "Crear Base de Conocimiento",
+      "EDIT": "Editar Base de Conocimiento"
+    },
+    "LABELS": {
+      "NAME": "Nombre",
+      "DESCRIPTION": "Descripción",
+      "VISIBILITY": "Visibilidad",
+      "GROUPS": "Grupos",
+      "PRIVATE": "Privado",
+      "PUBLIC": "Público",
+      "RESTRICTED": "Restringido"
+    },
+    "PLACEHOLDERS": {
+      "NAME": "Nombra tu base de conocimientos",
+      "DESCRIPTION": "Describe tu Base de Conocimientos y sus objetivos",
+      "SELECT_GROUP": "Seleccionar un grupo"
+    },
+    "BUTTONS": {
+      "CREATE": "Crear Conocimiento",
+      "UPDATE": "Actualizar Conocimiento",
+      "CANCEL": "Cancelar"
+    },
+    "MESSAGES": {
+      "NO_GROUPS": "No hay grupos con acceso, añade un grupo para otorgar acceso",
+      "PRIVATE_DESC": "Solo pueden acceder los usuarios y grupos con permiso",
+      "CREATE_SUCCESS": "Base de conocimiento creada correctamente",
+      "UPDATE_SUCCESS": "Base de conocimiento actualizada correctamente",
+      "CREATE_ERROR": "Error al crear la base de conocimiento",
+      "UPDATE_ERROR": "Error al actualizar la base de conocimiento"
+    }
+  },
+  "KNOWLEDGEBASEDETAIL": {
+    "TITLES": {
+      "DETAIL": "Detalle de Base de Conocimiento",
+      "FILES": "Archivos Asociados"
+    },
+    "LABELS": {
+      "NAME": "Nombre",
+      "DESCRIPTION": "Descripción",
+      "VISIBILITY": "Visibilidad",
+      "GROUPS": "Grupos",
+      "CREATED_AT": "Fecha de creación",
+      "UPDATED_AT": "Última actualización"
+    },
+    "BUTTONS": {
+      "EDIT": "Editar",
+      "DELETE": "Eliminar",
+      "ADD_FILES": "Añadir Archivos",
+      "DOWNLOAD": "Descargar",
+      "REMOVE_FILE": "Eliminar archivo"
+    },
+    "MESSAGES": {
+      "NO_FILES": "No hay archivos asociados",
+      "DELETE_CONFIRM": "¿Estás seguro de que quieres eliminar esta base de conocimiento?",
+      "DELETE_SUCCESS": "Base de conocimiento eliminada correctamente",
+      "DELETE_ERROR": "Error al eliminar la base de conocimiento"
+    }
+  },
+  "FILEUPLOAD": {
+    "TITLES": {
+      "UPLOAD_FILES": "Subir Archivos"
+    },
+    "LABELS": {
+      "DRAG_DROP": "Arrastra archivos aquí o haz clic para seleccionar",
+      "SELECTED_FILES": "Archivos seleccionados",
+      "UPLOAD_PROGRESS": "Progreso de carga"
+    },
+    "BUTTONS": {
+      "SELECT_FILES": "Seleccionar archivos",
+      "UPLOAD": "Subir",
+      "CANCEL": "Cancelar",
+      "REMOVE": "Eliminar"
+    },
+    "MESSAGES": {
+      "UPLOADING": "Subiendo...",
+      "ASSOCIATING": "Asociando archivo...",
+      "SUCCESS": "Archivo subido correctamente",
+      "ERROR": "Error al subir archivo",
+      "INVALID_TYPE": "Tipo de archivo no permitido",
+      "MAX_SIZE": "Archivo demasiado grande",
+      "UPLOAD_COMPLETE": "Todos los archivos se han subido correctamente"
+    }
+  },
+  "KNOWLEDGEBASELIST": {
+    "TITLES": {
+      "MAIN": "Bases de Conocimiento"
+    },
+    "COLUMNS": {
+      "NAME": "Nombre",
+      "DESCRIPTION": "Descripción",
+      "CREATED_AT": "Creado"
+    },
+    "BUTTONS": {
+      "ADD": "Añadir"
+    },
+    "EMPTY": {
+      "NO_RESULTS": "No hay bases de conocimiento"
+    }
+  }
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'bootstrap';


### PR DESCRIPTION
## Summary
- add standardized translations for Aside and knowledge base features
- update Aside component UI and routing
- standardize translation keys in knowledge base components
- enhance styles for active nav links
- initialize Bootstrap dropdowns and declare module typings

## Testing
- `npm run build`
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_688674c70e6c8325b1f930a6fdea264f