### PR TITLE
Standardize page templates

### DIFF
--- a/src/app/private/agent-chat/agent-chat-list.component.html
+++ b/src/app/private/agent-chat/agent-chat-list.component.html
@@ -1,11 +1,18 @@
-<div class="container-fluid d-flex flex-column gap-4">
-  <div class="d-flex justify-content-between align-items-center">
-    <h1>{{ "AGENT_CHAT_LIST.TITLES.MAIN" | transloco }}</h1>
+<div class="list-page__header">
+  <div class="list-page__header-actions">
+    <h2 class="list-page__title">
+      {{ "AGENT_CHAT_LIST.TITLES.MAIN" | transloco }}
+    </h2>
     <button class="btn btn-primary" [routerLink]="['./', 'add']">
       {{ "CHAT_LIST.NEW_CHAT_BUTTON" | transloco }}
     </button>
   </div>
+  <p class="list-page__description">
+    {{ "AGENT_CHAT_LIST.DESCRIPTIONS.MAIN" | transloco }}
+  </p>
+</div>
 
+<div class="list-page__content">
   <hub-ui-table
     [headers]="headers"
     [loading]="paginatedData.isLoading()"

--- a/src/app/private/agent-chat/agent-chat-list.component.ts
+++ b/src/app/private/agent-chat/agent-chat-list.component.ts
@@ -25,6 +25,9 @@ import { AgentChatService } from './agent-chat.service';
     TranslocoModule,
   ],
   templateUrl: './agent-chat-list.component.html',
+  host: {
+    class: 'list-page list-page--container',
+  },
 })
 export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
   override dataSvc = inject(AgentChatService);
@@ -45,7 +48,7 @@ export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
     },
     {
       title: this.translocoSvc.selectTranslate(
-        'AGENT_CHAT_LIST.COLUMNS.UPDATED'
+        'AGENT_CHAT_LIST.COLUMNS.UPDATED',
       ),
       property: 'updated_at',
     },
@@ -54,7 +57,7 @@ export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
       buttons: [
         {
           tooltip: upperFirst(
-            this.translocoSvc.translate('GENERIC.BUTTONS.REMOVE')
+            this.translocoSvc.translate('GENERIC.BUTTONS.REMOVE'),
           ),
           icon: { type: 'font-awesome', value: 'fa-trash' },
           classlist: 'btn text-danger',

--- a/src/app/private/agent-edition/agent-edition.component.html
+++ b/src/app/private/agent-edition/agent-edition.component.html
@@ -1,221 +1,234 @@
-<form
-  [formGroup]="form"
-  (ngSubmit)="onSubmit()"
-  class="container py-4 vstack gap-3"
-  (drop)="onDrop($event)"
-  (dragover)="$event.preventDefault()"
->
-  <div class="d-flex mb-3">
+<div class="list-page__header">
+  <div class="list-page__header-actions">
     <button type="button" class="btn btn-link me-2" routerLink="../">
       <i class="fas fa-arrow-left"></i>
     </button>
-    <h1 class="h3 mb-0">{{ "AGENT_EDITION.TITLES.MAIN" | transloco }}</h1>
+    <h2 class="list-page__title">
+      {{ "AGENT_EDITION.TITLES.MAIN" | transloco }}
+    </h2>
   </div>
+  <p class="list-page__description">
+    {{ "AGENT_EDITION.DESCRIPTIONS.MAIN" | transloco }}
+  </p>
+</div>
 
-  <div class="mb-3">
-    <label class="form-label">{{ "AGENT_FORM.LABELS.ID" | transloco }}</label>
-    <input class="form-control" type="text" formControlName="id" />
-  </div>
+<div class="list-page__content">
+  <form
+    [formGroup]="form"
+    (ngSubmit)="onSubmit()"
+    class="vstack gap-3"
+    (drop)="onDrop($event)"
+    (dragover)="$event.preventDefault()"
+  >
+    <div class="mb-3">
+      <label class="form-label">{{ "AGENT_FORM.LABELS.ID" | transloco }}</label>
+      <input class="form-control" type="text" formControlName="id" />
+    </div>
 
-  <div class="mb-3">
-    <label class="form-label">{{ "AGENT_FORM.LABELS.NAME" | transloco }}</label>
-    <input class="form-control" type="text" formControlName="name" />
-  </div>
+    <div class="mb-3">
+      <label class="form-label">{{
+        "AGENT_FORM.LABELS.NAME" | transloco
+      }}</label>
+      <input class="form-control" type="text" formControlName="name" />
+    </div>
 
-  <div class="mb-3" formGroupName="meta">
-    <label class="form-label">{{
-      "AGENT_FORM.LABELS.DESCRIPTION" | transloco
-    }}</label>
-    <textarea
-      rows="3"
-      class="form-control"
-      formControlName="description"
-    ></textarea>
-  </div>
+    <div class="mb-3" formGroupName="meta">
+      <label class="form-label">{{
+        "AGENT_FORM.LABELS.DESCRIPTION" | transloco
+      }}</label>
+      <textarea
+        rows="3"
+        class="form-control"
+        formControlName="description"
+      ></textarea>
+    </div>
 
-  <div class="mb-3" formGroupName="params">
-    <fieldset formGroupName="systemFields" class="border rounded p-3">
-      <legend class="float-none w-auto fs-6 mb-2">
-        {{ "AGENT_DESCRIPTION.TITLE" | transloco }}
-      </legend>
-      <p class="small text-muted">
-        {{ "AGENT_DESCRIPTION.INTRO" | transloco }}
-      </p>
+    <div class="mb-3" formGroupName="params">
+      <fieldset formGroupName="systemFields" class="border rounded p-3">
+        <legend class="float-none w-auto fs-6 mb-2">
+          {{ "AGENT_DESCRIPTION.TITLE" | transloco }}
+        </legend>
+        <p class="small text-muted">
+          {{ "AGENT_DESCRIPTION.INTRO" | transloco }}
+        </p>
 
-      <div class="mb-3">
-        <label class="form-label">
-          {{ "AGENT_DESCRIPTION.FIELDS.TONE" | transloco }}
-          <i
-            class="fas fa-question-circle ms-1"
-            [title]="'AGENT_DESCRIPTION.FIELDS.TONE' | transloco"
-          ></i>
-        </label>
-        <select class="form-select" formControlName="tone">
-          <option value=""></option>
-          <option value="CASUAL">
-            {{ "AGENT_EDITION.TONES.CASUAL" | transloco }}
-          </option>
-          <option value="PROFESSIONAL">
-            {{ "AGENT_EDITION.TONES.PROFESSIONAL" | transloco }}
-          </option>
-          <option value="CONCISE">
-            {{ "AGENT_EDITION.TONES.CONCISE" | transloco }}
-          </option>
-        </select>
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">
-          {{ "AGENT_DESCRIPTION.FIELDS.PERSONALITY" | transloco }}
-          <i
-            class="fas fa-question-circle ms-1"
-            [title]="'AGENT_DESCRIPTION.FIELDS.PERSONALITY' | transloco"
-          ></i>
-        </label>
-        <textarea
-          rows="2"
-          class="form-control"
-          formControlName="persona"
-        ></textarea>
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">
-          {{ "AGENT_DESCRIPTION.FIELDS.WELCOME" | transloco }}
-          <i
-            class="fas fa-question-circle ms-1"
-            [title]="'AGENT_DESCRIPTION.FIELDS.WELCOME' | transloco"
-          ></i>
-        </label>
-        <input
-          type="text"
-          class="form-control"
-          formControlName="welcomeMessage"
-        />
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">
-          {{ "AGENT_DESCRIPTION.FIELDS.CONTEXT" | transloco }}
-          <i
-            class="fas fa-question-circle ms-1"
-            [title]="'AGENT_DESCRIPTION.FIELDS.CONTEXT' | transloco"
-          ></i>
-        </label>
-        <textarea
-          rows="3"
-          class="form-control"
-          formControlName="context"
-        ></textarea>
-        @if (form.get('meta.descriptionFields.context')?.invalid &&
-        form.get('meta.descriptionFields.context')?.touched) {
-        <div class="text-danger">
-          {{ "AGENT_DESCRIPTION.VALIDATION.CONTEXT_REQUIRED" | transloco }}
+        <div class="mb-3">
+          <label class="form-label">
+            {{ "AGENT_DESCRIPTION.FIELDS.TONE" | transloco }}
+            <i
+              class="fas fa-question-circle ms-1"
+              [title]="'AGENT_DESCRIPTION.FIELDS.TONE' | transloco"
+            ></i>
+          </label>
+          <select class="form-select" formControlName="tone">
+            <option value=""></option>
+            <option value="CASUAL">
+              {{ "AGENT_EDITION.TONES.CASUAL" | transloco }}
+            </option>
+            <option value="PROFESSIONAL">
+              {{ "AGENT_EDITION.TONES.PROFESSIONAL" | transloco }}
+            </option>
+            <option value="CONCISE">
+              {{ "AGENT_EDITION.TONES.CONCISE" | transloco }}
+            </option>
+          </select>
         </div>
+
+        <div class="mb-3">
+          <label class="form-label">
+            {{ "AGENT_DESCRIPTION.FIELDS.PERSONALITY" | transloco }}
+            <i
+              class="fas fa-question-circle ms-1"
+              [title]="'AGENT_DESCRIPTION.FIELDS.PERSONALITY' | transloco"
+            ></i>
+          </label>
+          <textarea
+            rows="2"
+            class="form-control"
+            formControlName="persona"
+          ></textarea>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">
+            {{ "AGENT_DESCRIPTION.FIELDS.WELCOME" | transloco }}
+            <i
+              class="fas fa-question-circle ms-1"
+              [title]="'AGENT_DESCRIPTION.FIELDS.WELCOME' | transloco"
+            ></i>
+          </label>
+          <input
+            type="text"
+            class="form-control"
+            formControlName="welcomeMessage"
+          />
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">
+            {{ "AGENT_DESCRIPTION.FIELDS.CONTEXT" | transloco }}
+            <i
+              class="fas fa-question-circle ms-1"
+              [title]="'AGENT_DESCRIPTION.FIELDS.CONTEXT' | transloco"
+            ></i>
+          </label>
+          <textarea
+            rows="3"
+            class="form-control"
+            formControlName="context"
+          ></textarea>
+          @if (
+            form.get("meta.descriptionFields.context")?.invalid &&
+            form.get("meta.descriptionFields.context")?.touched
+          ) {
+            <div class="text-danger">
+              {{ "AGENT_DESCRIPTION.VALIDATION.CONTEXT_REQUIRED" | transloco }}
+            </div>
+          }
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">
+            {{ "AGENT_DESCRIPTION.FIELDS.OUTPUT" | transloco }}
+            <i
+              class="fas fa-question-circle ms-1"
+              [title]="'AGENT_DESCRIPTION.FIELDS.OUTPUT' | transloco"
+            ></i>
+          </label>
+          <input
+            type="text"
+            class="form-control"
+            formControlName="outputFormat"
+          />
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">{{
+        "AGENT_FORM.LABELS.BASE_MODEL" | transloco
+      }}</label>
+      <ng-select
+        [items]="modelsResource.value()"
+        [loading]="modelsResource.isLoading()"
+        bindLabel="name"
+        bindValue="id"
+        formControlName="base_model_id"
+      ></ng-select>
+    </div>
+
+    <div class="mb-3" formGroupName="meta">
+      <label class="form-label">
+        {{ "AGENT_FORM.LABELS.CAPABILITIES" | transloco }}
+        <i
+          class="fas fa-question-circle ms-1"
+          [title]="'AGENT_FORM.TIPS.CAPABILITIES' | transloco"
+        ></i>
+      </label>
+      <div formGroupName="capabilities" class="d-flex flex-wrap gap-3">
+        @for (cap of capabilities; track cap) {
+          <div class="form-check">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              [id]="cap"
+              [formControlName]="cap"
+            />
+            <label class="form-check-label" [for]="cap">{{
+              cap | titlecase
+            }}</label>
+          </div>
         }
       </div>
+    </div>
 
-      <div class="mb-3">
-        <label class="form-label">
-          {{ "AGENT_DESCRIPTION.FIELDS.OUTPUT" | transloco }}
-          <i
-            class="fas fa-question-circle ms-1"
-            [title]="'AGENT_DESCRIPTION.FIELDS.OUTPUT' | transloco"
-          ></i>
-        </label>
+    <div class="mb-3" formGroupName="meta">
+      <label class="form-label">{{
+        "AGENT_FORM.LABELS.KNOWLEDGE" | transloco
+      }}</label>
+      <ng-select
+        [items]="knowledgeResource.value()"
+        [loading]="knowledgeResource.isLoading()"
+        bindLabel="name"
+        [multiple]="true"
+        formControlName="knowledge"
+      ></ng-select>
+    </div>
+
+    <div class="mb-3" formGroupName="meta">
+      <label class="form-label">{{
+        "AGENT_FORM.LABELS.PROFILE_IMAGE" | transloco
+      }}</label>
+      <div class="border rounded p-3 text-center">
+        @if (imagePreview) {
+          <img [src]="imagePreview" class="img-thumbnail mb-2" alt="preview" />
+        }
         <input
-          type="text"
+          type="file"
+          accept="image/*"
           class="form-control"
-          formControlName="outputFormat"
+          (change)="onImageSelect($event)"
         />
+        <small class="text-muted">{{
+          "AGENT_EDITION.FORM.DRAG_DROP" | transloco
+        }}</small>
       </div>
-    </fieldset>
-  </div>
-
-  <div class="mb-3">
-    <label class="form-label">{{
-      "AGENT_FORM.LABELS.BASE_MODEL" | transloco
-    }}</label>
-    <ng-select
-      [items]="modelsResource.value()"
-      [loading]="modelsResource.isLoading()"
-      bindLabel="name"
-      bindValue="id"
-      formControlName="base_model_id"
-    ></ng-select>
-  </div>
-
-  <div class="mb-3" formGroupName="meta">
-    <label class="form-label">
-      {{ "AGENT_FORM.LABELS.CAPABILITIES" | transloco }}
-      <i
-        class="fas fa-question-circle ms-1"
-        [title]="'AGENT_FORM.TIPS.CAPABILITIES' | transloco"
-      ></i>
-    </label>
-    <div formGroupName="capabilities" class="d-flex flex-wrap gap-3">
-      @for (cap of capabilities; track cap) {
-      <div class="form-check">
-        <input
-          type="checkbox"
-          class="form-check-input"
-          [id]="cap"
-          [formControlName]="cap"
-        />
-        <label class="form-check-label" [for]="cap">{{
-          cap | titlecase
-        }}</label>
-      </div>
-      }
     </div>
-  </div>
 
-  <div class="mb-3" formGroupName="meta">
-    <label class="form-label">{{
-      "AGENT_FORM.LABELS.KNOWLEDGE" | transloco
-    }}</label>
-    <ng-select
-      [items]="knowledgeResource.value()"
-      [loading]="knowledgeResource.isLoading()"
-      bindLabel="name"
-      [multiple]="true"
-      formControlName="knowledge"
-    ></ng-select>
-  </div>
-
-  <div class="mb-3" formGroupName="meta">
-    <label class="form-label">{{
-      "AGENT_FORM.LABELS.PROFILE_IMAGE" | transloco
-    }}</label>
-    <div class="border rounded p-3 text-center">
-      @if (imagePreview) {
-      <img [src]="imagePreview" class="img-thumbnail mb-2" alt="preview" />
-      }
+    <div class="form-check mb-3">
       <input
-        type="file"
-        accept="image/*"
-        class="form-control"
-        (change)="onImageSelect($event)"
+        type="checkbox"
+        class="form-check-input"
+        formControlName="is_active"
+        id="active"
       />
-      <small class="text-muted">{{
-        "AGENT_EDITION.FORM.DRAG_DROP" | transloco
-      }}</small>
+      <label for="active" class="form-check-label">{{
+        "AGENT_FORM.LABELS.ACTIVE" | transloco
+      }}</label>
     </div>
-  </div>
 
-  <div class="form-check mb-3">
-    <input
-      type="checkbox"
-      class="form-check-input"
-      formControlName="is_active"
-      id="active"
-    />
-    <label for="active" class="form-check-label">{{
-      "AGENT_FORM.LABELS.ACTIVE" | transloco
-    }}</label>
-  </div>
-
-  <button type="submit" class="btn btn-primary w-100">
-    {{ "AGENT_EDITION.BUTTONS.SAVE" | transloco }}
-  </button>
-</form>
+    <button type="submit" class="btn btn-primary w-100">
+      {{ "AGENT_EDITION.BUTTONS.SAVE" | transloco }}
+    </button>
+  </form>
+</div>

--- a/src/app/private/agent-edition/agent-edition.component.ts
+++ b/src/app/private/agent-edition/agent-edition.component.ts
@@ -33,6 +33,9 @@ import { AGENT_CAPABILITIES } from './agent-capability.enum';
   ],
   templateUrl: './agent-edition.component.html',
   styleUrl: './agent-edition.component.scss',
+  host: {
+    class: 'list-page list-page--container',
+  },
 })
 export class AgentEditionComponent {
   private fb = inject(FormBuilder);
@@ -251,7 +254,7 @@ export class AgentEditionComponent {
    * group controls.
    */
   private parseCapabilitiesToForm(
-    capabilities: Partial<Record<string, boolean>>
+    capabilities: Partial<Record<string, boolean>>,
   ): void {
     const group = this.form.controls.meta.controls.capabilities;
     for (const key of this.capabilities) {

--- a/src/app/private/knowledge-base/knowledge-base-detail.component.html
+++ b/src/app/private/knowledge-base/knowledge-base-detail.component.html
@@ -1,29 +1,35 @@
 @if (knowledge(); as kb) {
-<div class="container py-4">
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="m-0">{{ kb.name }}</h1>
-    <a
-      class="btn btn-outline-primary btn-sm"
-      [routerLink]="['/private/knowledge-bases', kb.id, 'edit']"
-    >
-      <i class="bi bi-pencil"></i>
-      {{ 'KNOWLEDGEBASEDETAIL.BUTTONS.EDIT' | transloco }}
-    </a>
-  </div>
-  <p>{{ kb.description }}</p>
-  <app-file-upload [knowledgeBaseId]="kb.id" class="mb-4"></app-file-upload>
-  <div class="row g-3">
-    @for (file of kb.files; track file) {
-    <div class="col-md-6 col-lg-4">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body">
-          <h6 class="card-title">{{ file.meta.name || file.id }}</h6>
-        </div>
-      </div>
+  <div class="list-page__header">
+    <div class="list-page__header-actions">
+      <h2 class="list-page__title">{{ kb.name }}</h2>
+      <a
+        class="btn btn-outline-primary btn-sm"
+        [routerLink]="['/private/knowledge-bases', kb.id, 'edit']"
+      >
+        <i class="bi bi-pencil"></i>
+        {{ "KNOWLEDGEBASEDETAIL.BUTTONS.EDIT" | transloco }}
+      </a>
     </div>
-    } @empty {
-    <p>{{ 'KNOWLEDGEBASEDETAIL.MESSAGES.NO_FILES' | transloco }}</p>
-    }
+    <p class="list-page__description">
+      {{ "KNOWLEDGEBASEDETAIL.DESCRIPTIONS.MAIN" | transloco }}
+    </p>
   </div>
-</div>
+
+  <div class="list-page__content">
+    <p>{{ kb.description }}</p>
+    <app-file-upload [knowledgeBaseId]="kb.id" class="mb-4"></app-file-upload>
+    <div class="row g-3">
+      @for (file of kb.files; track file) {
+        <div class="col-md-6 col-lg-4">
+          <div class="card h-100 shadow-sm border-0">
+            <div class="card-body">
+              <h6 class="card-title">{{ file.meta.name || file.id }}</h6>
+            </div>
+          </div>
+        </div>
+      } @empty {
+        <p>{{ "KNOWLEDGEBASEDETAIL.MESSAGES.NO_FILES" | transloco }}</p>
+      }
+    </div>
+  </div>
 }

--- a/src/app/private/knowledge-base/knowledge-base-detail.component.ts
+++ b/src/app/private/knowledge-base/knowledge-base-detail.component.ts
@@ -9,6 +9,9 @@ import { FileUploadComponent } from './file-upload.component';
   standalone: true,
   imports: [FileUploadComponent, RouterLink, TranslocoModule],
   templateUrl: './knowledge-base-detail.component.html',
+  host: {
+    class: 'list-page list-page--container',
+  },
 })
 export class KnowledgeBaseDetailComponent {
   knowledge = input.required<KnowledgeBase>({ alias: 'knowledge' });

--- a/src/app/private/knowledge-base/knowledge-base-edition.component.html
+++ b/src/app/private/knowledge-base/knowledge-base-edition.component.html
@@ -1,5 +1,13 @@
-<div class="container-fluid py-4">
-  <h1 class="mb-4">{{ formTitle() }}</h1>
+<div class="list-page__header">
+  <div class="list-page__header-actions">
+    <h2 class="list-page__title">{{ formTitle() }}</h2>
+  </div>
+  <p class="list-page__description">
+    {{ "KNOWLEDGEBASEEDITION.DESCRIPTIONS.MAIN" | transloco }}
+  </p>
+</div>
+
+<div class="list-page__content">
   <form [formGroup]="form" (ngSubmit)="submit()" class="vstack gap-3">
     <div class="form-floating mb-3">
       <input
@@ -9,7 +17,9 @@
         class="form-control"
         placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.NAME' | transloco }}"
       />
-      <label for="name">{{ 'KNOWLEDGEBASEEDITION.LABELS.NAME' | transloco }}</label>
+      <label for="name">{{
+        "KNOWLEDGEBASEEDITION.LABELS.NAME" | transloco
+      }}</label>
     </div>
 
     <div class="form-floating mb-3">
@@ -18,30 +28,32 @@
         formControlName="description"
         class="form-control"
         style="height: 120px"
-        placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.DESCRIPTION' | transloco }}"
+        placeholder="{{
+          'KNOWLEDGEBASEEDITION.PLACEHOLDERS.DESCRIPTION' | transloco
+        }}"
       ></textarea>
       <label for="description">
-        {{ 'KNOWLEDGEBASEEDITION.LABELS.DESCRIPTION' | transloco }}
+        {{ "KNOWLEDGEBASEEDITION.LABELS.DESCRIPTION" | transloco }}
       </label>
     </div>
 
     <div class="mb-3">
       <label class="form-label">
-        {{ 'KNOWLEDGEBASEEDITION.LABELS.VISIBILITY' | transloco }}
+        {{ "KNOWLEDGEBASEEDITION.LABELS.VISIBILITY" | transloco }}
       </label>
       <select formControlName="visibility" class="form-select">
         <option value="private">
-          {{ 'KNOWLEDGEBASEEDITION.LABELS.PRIVATE' | transloco }}
+          {{ "KNOWLEDGEBASEEDITION.LABELS.PRIVATE" | transloco }}
         </option>
       </select>
       <div class="form-text">
-        {{ 'KNOWLEDGEBASEEDITION.MESSAGES.PRIVATE_DESC' | transloco }}
+        {{ "KNOWLEDGEBASEEDITION.MESSAGES.PRIVATE_DESC" | transloco }}
       </div>
     </div>
 
     <div class="mb-3">
       <label class="form-label">
-        {{ 'KNOWLEDGEBASEEDITION.LABELS.GROUPS' | transloco }}
+        {{ "KNOWLEDGEBASEEDITION.LABELS.GROUPS" | transloco }}
       </label>
       <ng-select
         [items]="groups.value()"
@@ -50,21 +62,23 @@
         bindLabel="name"
         bindValue="id"
         [multiple]="true"
-        placeholder="{{ 'KNOWLEDGEBASEEDITION.PLACEHOLDERS.SELECT_GROUP' | transloco }}"
+        placeholder="{{
+          'KNOWLEDGEBASEEDITION.PLACEHOLDERS.SELECT_GROUP' | transloco
+        }}"
         formControlName="groups"
       ></ng-select>
       @if (!groups.value()?.length) {
-      <div class="form-text">
-        {{ 'KNOWLEDGEBASEEDITION.MESSAGES.NO_GROUPS' | transloco }}
-      </div>
+        <div class="form-text">
+          {{ "KNOWLEDGEBASEEDITION.MESSAGES.NO_GROUPS" | transloco }}
+        </div>
       }
     </div>
 
     <button type="submit" class="btn btn-primary btn-lg w-100">
       {{
         isEditMode()
-          ? ('KNOWLEDGEBASEEDITION.BUTTONS.UPDATE' | transloco)
-          : ('KNOWLEDGEBASEEDITION.BUTTONS.CREATE' | transloco)
+          ? ("KNOWLEDGEBASEEDITION.BUTTONS.UPDATE" | transloco)
+          : ("KNOWLEDGEBASEEDITION.BUTTONS.CREATE" | transloco)
       }}
     </button>
   </form>

--- a/src/app/private/knowledge-base/knowledge-base-edition.component.ts
+++ b/src/app/private/knowledge-base/knowledge-base-edition.component.ts
@@ -1,4 +1,3 @@
-
 import {
   Component,
   computed,
@@ -22,6 +21,9 @@ import { KnowledgeBaseService } from './knowledge-base.service';
   standalone: true,
   imports: [ReactiveFormsModule, NgSelectModule, TranslocoModule],
   templateUrl: './knowledge-base-edition.component.html',
+  host: {
+    class: 'list-page list-page--container',
+  },
 })
 export class KnowledgeBaseEditionComponent {
   #fb = inject(FormBuilder);
@@ -32,7 +34,7 @@ export class KnowledgeBaseEditionComponent {
   #transloco = inject(TranslocoService);
 
   knowledgeBaseId = toSignal(
-    this.#route.paramMap.pipe(map((m) => m.get('knowledgeId')))
+    this.#route.paramMap.pipe(map((m) => m.get('knowledgeId'))),
   );
 
   groups = resource({
@@ -60,7 +62,7 @@ export class KnowledgeBaseEditionComponent {
   readonly formTitle = computed(() =>
     this.isEditMode()
       ? this.#transloco.translate('KNOWLEDGEBASEEDITION.TITLES.EDIT')
-      : this.#transloco.translate('KNOWLEDGEBASEEDITION.TITLES.CREATE')
+      : this.#transloco.translate('KNOWLEDGEBASEEDITION.TITLES.CREATE'),
   );
 
   submit() {

--- a/src/app/private/knowledge-list/knowledge-list.component.html
+++ b/src/app/private/knowledge-list/knowledge-list.component.html
@@ -1,12 +1,18 @@
-<div class="container-fluid d-flex flex-column gap-4">
-  <h1>{{ 'KNOWLEDGEBASELIST.TITLES.MAIN' | transloco }}</h1>
-
-  <div class="d-flex justify-content-end gap-2">
+<div class="list-page__header">
+  <div class="list-page__header-actions">
+    <h2 class="list-page__title">
+      {{ "KNOWLEDGEBASELIST.TITLES.MAIN" | transloco }}
+    </h2>
     <button class="btn btn-primary" [routerLink]="['.', 'add']">
-      {{ 'KNOWLEDGEBASELIST.BUTTONS.ADD' | transloco }}
+      {{ "KNOWLEDGEBASELIST.BUTTONS.ADD" | transloco }}
     </button>
   </div>
+  <p class="list-page__description">
+    {{ "KNOWLEDGEBASELIST.DESCRIPTIONS.MAIN" | transloco }}
+  </p>
+</div>
 
+<div class="list-page__content">
   <hub-ui-table
     [headers]="headers"
     [loading]="paginatedData.isLoading()"
@@ -25,7 +31,7 @@
       {{ formatDate(property) }}
     </ng-template>
     <ng-template noDataTpt>
-      {{ 'KNOWLEDGEBASELIST.EMPTY.NO_RESULTS' | transloco }}
+      {{ "KNOWLEDGEBASELIST.EMPTY.NO_RESULTS" | transloco }}
     </ng-template>
   </hub-ui-table>
 </div>

--- a/src/app/private/knowledge-list/knowledge-list.component.ts
+++ b/src/app/private/knowledge-list/knowledge-list.component.ts
@@ -22,24 +22,29 @@ import { KnowledgeBase } from './knowledge-base.model';
     TranslocoModule,
   ],
   templateUrl: './knowledge-list.component.html',
+  host: {
+    class: 'list-page list-page--container',
+  },
 })
 export class KnowledgeListComponent extends PaginatedListComponent<KnowledgeBase> {
   override dataSvc = inject(KnowledgeBaseService);
 
   override headers: PaginableTableHeader[] = [
     {
-      title: this.translocoSvc.selectTranslate('KNOWLEDGEBASELIST.COLUMNS.NAME'),
+      title: this.translocoSvc.selectTranslate(
+        'KNOWLEDGEBASELIST.COLUMNS.NAME',
+      ),
       property: 'name',
     },
     {
       title: this.translocoSvc.selectTranslate(
-        'KNOWLEDGEBASELIST.COLUMNS.DESCRIPTION'
+        'KNOWLEDGEBASELIST.COLUMNS.DESCRIPTION',
       ),
       property: 'description',
     },
     {
       title: this.translocoSvc.selectTranslate(
-        'KNOWLEDGEBASELIST.COLUMNS.CREATED_AT'
+        'KNOWLEDGEBASELIST.COLUMNS.CREATED_AT',
       ),
       property: 'created_at',
     },

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3,6 +3,9 @@
     "TITLES": {
       "MAIN": "Agent Chats"
     },
+    "DESCRIPTIONS": {
+      "MAIN": "Chats between users and agents"
+    },
     "COLUMNS": {
       "ID": "Id",
       "AGENT": "Agent",
@@ -105,6 +108,9 @@
   "AGENT_LIST": {
     "TITLES": {
       "MAIN": "Agents"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Manage your agents"
     },
     "COLUMNS": {
       "PIN": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,6 +3,9 @@
     "TITLES": {
       "MAIN": "Agent Chats"
     },
+    "DESCRIPTIONS": {
+      "MAIN": "Chats between users and agents"
+    },
     "COLUMNS": {
       "ID": "Id",
       "AGENT": "Agent",
@@ -42,6 +45,9 @@
   "AGENT_EDITION": {
     "TITLES": {
       "MAIN": "Agent"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Create or edit an agent"
     },
     "LABELS": {
       "NAME": "Name",
@@ -105,6 +111,9 @@
   "AGENT_LIST": {
     "TITLES": {
       "MAIN": "Agents"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Manage your agents"
     },
     "COLUMNS": {
       "PIN": "",
@@ -316,8 +325,7 @@
     "public": "Public",
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
-  }
-  ,
+  },
   "ASIDE": {
     "LABELS": {
       "HOME": "Home",
@@ -342,6 +350,9 @@
     "TITLES": {
       "CREATE": "Create Knowledge Base",
       "EDIT": "Edit Knowledge Base"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Create or edit a knowledge base"
     },
     "LABELS": {
       "NAME": "Name",
@@ -375,6 +386,9 @@
     "TITLES": {
       "DETAIL": "Knowledge Base Detail",
       "FILES": "Associated Files"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Details of the selected knowledge base"
     },
     "LABELS": {
       "NAME": "Name",
@@ -426,6 +440,9 @@
   "KNOWLEDGEBASELIST": {
     "TITLES": {
       "MAIN": "Knowledge Bases"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Manage your knowledge bases"
     },
     "COLUMNS": {
       "NAME": "Name",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3,6 +3,9 @@
     "TITLES": {
       "MAIN": "Agent Chats"
     },
+    "DESCRIPTIONS": {
+      "MAIN": "Conversaciones de tus agentes"
+    },
     "COLUMNS": {
       "ID": "Id",
       "AGENT": "Agent",
@@ -42,6 +45,9 @@
   "AGENT_EDITION": {
     "TITLES": {
       "MAIN": "Agent"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Crea o edita un agente"
     },
     "LABELS": {
       "NAME": "Name",
@@ -105,6 +111,9 @@
   "AGENT_LIST": {
     "TITLES": {
       "MAIN": "Agents"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Administra tus agentes"
     },
     "COLUMNS": {
       "PIN": "",
@@ -316,8 +325,7 @@
     "public": "Público",
     "restricted": "Restringido",
     "privateDesc": "Solo pueden acceder los usuarios y grupos con permiso"
-  }
-  ,
+  },
   "ASIDE": {
     "LABELS": {
       "HOME": "Inicio",
@@ -342,6 +350,9 @@
     "TITLES": {
       "CREATE": "Crear Base de Conocimiento",
       "EDIT": "Editar Base de Conocimiento"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Crea o edita una base de conocimiento"
     },
     "LABELS": {
       "NAME": "Nombre",
@@ -375,6 +386,9 @@
     "TITLES": {
       "DETAIL": "Detalle de Base de Conocimiento",
       "FILES": "Archivos Asociados"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Información de la base de conocimiento"
     },
     "LABELS": {
       "NAME": "Nombre",
@@ -426,6 +440,9 @@
   "KNOWLEDGEBASELIST": {
     "TITLES": {
       "MAIN": "Bases de Conocimiento"
+    },
+    "DESCRIPTIONS": {
+      "MAIN": "Gestiona tus bases de conocimiento"
     },
     "COLUMNS": {
       "NAME": "Nombre",


### PR DESCRIPTION
## Summary
- unify host classes for list, detail and edition components
- standardize HTML headers and content areas
- add missing description translations in Spanish and English
- format updated HTML and TS files

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_688678a19e7c83258227c9240f863ba5