### PR TITLE
Implement chat pinning

### DIFF
--- a/src/app/chat/chat.service.ts
+++ b/src/app/chat/chat.service.ts
@@ -61,6 +61,27 @@ export class ChatService {
   readonly pinnedChats = this.pinnedChatsResource.value;
   readonly isLoadingPinned = this.pinnedChatsResource.isLoading;
 
+  /** Pin a chat and refresh the pinned list */
+  async pinChat(chatId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.post(`${environment.baseURL}/chats/${chatId}/pin`, {})
+    );
+    this.pinnedChatsResource.reload();
+  }
+
+  /** Unpin a chat and refresh the pinned list */
+  async unpinChat(chatId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.post(`${environment.baseURL}/chats/${chatId}/unpin`, {})
+    );
+    this.pinnedChatsResource.reload();
+  }
+
+  /** Check if chat is currently pinned */
+  isPinned(chatId: string | number | null | undefined): boolean {
+    return this.pinnedChats()?.some((c) => c.id === String(chatId)) ?? false;
+  }
+
   // Estados reactivos como en Svelte
   chatHistory = new BehaviorSubject<ChatHistory>({
     messages: {},

--- a/src/app/private/agent-chat/agent-chat-list.component.html
+++ b/src/app/private/agent-chat/agent-chat-list.component.html
@@ -31,6 +31,31 @@
     <ng-template cellTpt header="updated_at" let-property="property">
       {{ formatDate(property) }}
     </ng-template>
+    <ng-template cellTpt header="pin" let-row="row">
+      <button
+        type="button"
+        class="btn btn-link p-0 pin-btn"
+        [class.pinned]="isPinned(row)"
+        [attr.aria-label]="
+          isPinned(row)
+            ? ('CHATLIST.BUTTONS.UNPIN_CHAT' | transloco)
+            : ('CHATLIST.BUTTONS.PIN_CHAT' | transloco)
+        "
+        (click)="togglePin(row); $event.stopPropagation()"
+        [disabled]="loadingPins().has(row.id)"
+      >
+        <ng-container *ngIf="!loadingPins().has(row.id); else loading">
+          <i
+            class="bi"
+            [class.bi-pin-fill]="isPinned(row)"
+            [class.bi-pin]="!isPinned(row)"
+          ></i>
+        </ng-container>
+        <ng-template #loading>
+          <span class="spinner-border spinner-border-sm"></span>
+        </ng-template>
+      </button>
+    </ng-template>
     <ng-template noDataTpt>
       {{ "CHAT_LIST.NO_CHATS" | transloco }}
     </ng-template>

--- a/src/app/private/agent-chat/agent-chat-list.component.scss
+++ b/src/app/private/agent-chat/agent-chat-list.component.scss
@@ -1,0 +1,8 @@
+.pin-btn {
+  visibility: hidden;
+}
+
+tr:hover .pin-btn,
+.pin-btn.pinned {
+  visibility: visible;
+}

--- a/src/app/private/agent-chat/agent-chat-list.component.ts
+++ b/src/app/private/agent-chat/agent-chat-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { upperFirst } from 'lodash';
@@ -13,6 +13,8 @@ import { firstValueFrom } from 'rxjs';
 import { PaginatedListComponent } from '../../shared/components/paginated-list.component';
 import { AgentChat } from './agent-chat.model';
 import { AgentChatService } from './agent-chat.service';
+import { ChatService } from '../../chat/chat.service';
+import { Toast } from '../../shared/services/toast.service';
 
 @Component({
   selector: 'app-agent-chat-list',
@@ -25,6 +27,7 @@ import { AgentChatService } from './agent-chat.service';
     TranslocoModule,
   ],
   templateUrl: './agent-chat-list.component.html',
+  styleUrls: ['./agent-chat-list.component.scss'],
   host: {
     class: 'list-page list-page--container',
   },
@@ -33,11 +36,56 @@ export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
   override dataSvc = inject(AgentChatService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private chatSvc = inject(ChatService);
+
+  /** Track chats currently being processed */
+  loadingPins = signal<Set<string>>(new Set());
+
+  /** Determine if a chat is pinned */
+  isPinned = (chat: AgentChat) => this.chatSvc.isPinned(chat.id);
+
+  /** Toggle pin state of a chat */
+  async togglePin(chat: AgentChat): Promise<void> {
+    const id = String(chat.id);
+    this.loadingPins.update((set) => new Set(set).add(id));
+    try {
+      if (this.isPinned(chat)) {
+        await this.chatSvc.unpinChat(id);
+        Toast.success(
+          this.translocoSvc.translate('CHATLIST.MESSAGES.UNPIN_SUCCESS')
+        );
+      } else {
+        await this.chatSvc.pinChat(id);
+        Toast.success(
+          this.translocoSvc.translate('CHATLIST.MESSAGES.PIN_SUCCESS')
+        );
+      }
+    } catch {
+      Toast.error(
+        this.translocoSvc.translate(
+          this.isPinned(chat)
+            ? 'CHATLIST.MESSAGES.UNPIN_ERROR'
+            : 'CHATLIST.MESSAGES.PIN_ERROR'
+        )
+      );
+    } finally {
+      this.loadingPins.update((set) => {
+        const newSet = new Set(set);
+        newSet.delete(id);
+        return newSet;
+      });
+    }
+  }
 
   /** Currently selected agent identifier */
   agentId = input(null, { alias: 'agentId' });
 
   override headers: PaginableTableHeader[] = [
+    {
+      title: '',
+      property: 'pin',
+      sortable: false,
+    },
     {
       title: this.translocoSvc.selectTranslate('AGENT_CHAT_LIST.COLUMNS.ID'),
       property: 'id',

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -282,5 +282,17 @@
     "BUTTONS": {
       "REMOVE": "Eliminar"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -288,5 +288,17 @@
     "BUTTONS": {
       "REMOVE": "Eliminar"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -316,5 +316,17 @@
     "public": "Public",
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -455,5 +455,17 @@
     "EMPTY": {
       "NO_RESULTS": "No knowledge bases found"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -455,5 +455,17 @@
     "EMPTY": {
       "NO_RESULTS": "No hay bases de conocimiento"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -282,5 +282,17 @@
     "BUTTONS": {
       "REMOVE": "Eliminar"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -316,5 +316,17 @@
     "public": "Public",
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -282,5 +282,17 @@
     "BUTTONS": {
       "REMOVE": "Eliminar"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -316,5 +316,17 @@
     "public": "Public",
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/oc.json
+++ b/src/assets/i18n/oc.json
@@ -282,5 +282,17 @@
     "BUTTONS": {
       "REMOVE": "Eliminar"
     }
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -316,5 +316,17 @@
     "public": "Public",
     "restricted": "Restricted",
     "privateDesc": "Only allowed users and groups can access"
+  },
+  "CHATLIST": {
+    "BUTTONS": {
+      "PIN_CHAT": "Pin chat",
+      "UNPIN_CHAT": "Unpin chat"
+    },
+    "MESSAGES": {
+      "PIN_SUCCESS": "Chat pinned",
+      "UNPIN_SUCCESS": "Chat unpinned",
+      "PIN_ERROR": "Error pinning chat",
+      "UNPIN_ERROR": "Error unpinning chat"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow pin/unpin chats via `ChatService`
- display pin button in chat list
- show loading state and toast messages
- add pinned chat translations
- style pin button

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_68867eb767e48325a3d07378c2a449c2