### PR TITLE
Fix language submenu overflow

### DIFF
--- a/src/app/private/layout/aside/aside.component.ts
+++ b/src/app/private/layout/aside/aside.component.ts
@@ -172,6 +172,16 @@ export class AsideComponent implements OnDestroy {
         langEl.addEventListener('click', (ev) => {
           ev.stopPropagation();
         });
+
+        langEl.addEventListener('shown.bs.dropdown', () => {
+          const layout = document.querySelector('.private-layout');
+          layout?.classList.add('overflow-visible');
+        });
+
+        langEl.addEventListener('hidden.bs.dropdown', () => {
+          const layout = document.querySelector('.private-layout');
+          layout?.classList.remove('overflow-visible');
+        });
       }
     });
   }

--- a/src/app/private/layout/private-layout.component.scss
+++ b/src/app/private/layout/private-layout.component.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.private-layout.overflow-visible {
+  overflow: visible;
+}
+
 .offcanvas {
   height: 100vh;
 


### PR DESCRIPTION
## Summary
- ensure private layout can turn off overflow
- toggle layout overflow when language dropdown shows

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_6886aa4496048325a15e2402aacd91b9