### PR TITLE
Implement pinned chat polling and toggle

### DIFF
--- a/src/app/private/agent-chat/agent-chat-list.component.ts
+++ b/src/app/private/agent-chat/agent-chat-list.component.ts
@@ -50,22 +50,20 @@ export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
   async togglePin(chat: AgentChat): Promise<void> {
     const id = String(chat.id);
     this.loadingPins.update((set) => new Set(set).add(id));
+    const currentlyPinned = this.isPinned(chat);
     try {
-      if (this.isPinned(chat)) {
-        await this.chatSvc.unpinChat(id);
-        Toast.success(
-          this.translocoSvc.translate('CHATLIST.MESSAGES.UNPIN_SUCCESS')
-        );
-      } else {
-        await this.chatSvc.pinChat(id);
-        Toast.success(
-          this.translocoSvc.translate('CHATLIST.MESSAGES.PIN_SUCCESS')
-        );
-      }
+      await this.chatSvc.toggleChatPin(id);
+      Toast.success(
+        this.translocoSvc.translate(
+          currentlyPinned
+            ? 'CHATLIST.MESSAGES.UNPIN_SUCCESS'
+            : 'CHATLIST.MESSAGES.PIN_SUCCESS'
+        )
+      );
     } catch {
       Toast.error(
         this.translocoSvc.translate(
-          this.isPinned(chat)
+          currentlyPinned
             ? 'CHATLIST.MESSAGES.UNPIN_ERROR'
             : 'CHATLIST.MESSAGES.PIN_ERROR'
         )

--- a/src/app/private/agent-chat/agent-chat.component.html
+++ b/src/app/private/agent-chat/agent-chat.component.html
@@ -1,7 +1,26 @@
 <!-- chat.component.html -->
 <div class="detail-page__header">
-  <div class="d-flex justify-content-between">
-    <h2>{{ chat()?.title }}</h2>
+  <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex align-items-center gap-2">
+      <h2 class="m-0">{{ chat()?.title }}</h2>
+      <button
+        type="button"
+        class="btn btn-link p-0"
+        (click)="togglePin()"
+        [disabled]="loadingPin()"
+        [attr.aria-label]="
+          pinned()
+            ? ('CHATLIST.BUTTONS.UNPIN_CHAT' | transloco)
+            : ('CHATLIST.BUTTONS.PIN_CHAT' | transloco)
+        "
+      >
+        @if (!loadingPin()) {
+        <i class="bi" [class.bi-pin-fill]="pinned()" [class.bi-pin]="!pinned()"></i>
+        } @else {
+        <span class="spinner-border spinner-border-sm"></span>
+        }
+      </button>
+    </div>
     <ng-select
       [items]="agents.value()"
       [loading]="agents.isLoading()"

--- a/src/app/private/agent-chat/agent-chat.component.ts
+++ b/src/app/private/agent-chat/agent-chat.component.ts
@@ -9,6 +9,7 @@ import {
   model,
   resource,
   signal,
+  computed,
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -20,6 +21,7 @@ import { Agent } from '../agent-list/agent';
 import { AgentsService } from '../agent-list/agents.service';
 import { AgentChat, Message } from './agent-chat.model';
 import { AgentChatService } from './agent-chat.service';
+import { ChatService } from '../../chat/chat.service';
 
 @Component({
   selector: 'app-agent-chat',
@@ -41,6 +43,7 @@ export class AgentChatComponent {
   private chatsSvc = inject(AgentChatService);
   private agentsSvc = inject(AgentsService);
   private activateRoute = inject(ActivatedRoute);
+  private chatSvc = inject(ChatService);
   #location = inject(Location);
   transloco = inject(TranslocoService);
 
@@ -71,6 +74,10 @@ export class AgentChatComponent {
   loading = signal(false);
   /** Error flag when the chat cannot be retrieved */
   error = signal(false);
+
+  /** Pinned state and loading flag */
+  pinned = computed(() => this.chatSvc.isPinned(this.chatId()));
+  loadingPin = signal(false);
 
   /** Input model */
   currentMessage = '';
@@ -215,5 +222,17 @@ export class AgentChatComponent {
     // if (chatId !== 'local') {
     //   await this.chatService.quickUpdateChat(chatId, { params: this.chatParams });
     // }
+  }
+
+  /** Toggle pin state for the current chat */
+  async togglePin(): Promise<void> {
+    const id = this.chatId();
+    if (!id) return;
+    this.loadingPin.set(true);
+    try {
+      await this.chatSvc.toggleChatPin(id);
+    } finally {
+      this.loadingPin.set(false);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement polling and toggle endpoints in `ChatService`
- update agent chat list to use toggle API
- show pin/unpin button in chat header and allow toggling

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_68887510d5b083258c4d5a62d60753fc