### PR TITLE
Add pinned chat indicators and unpin button

### DIFF
--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -486,14 +486,14 @@
   },
   "CHATLIST": {
     "BUTTONS": {
-      "PIN_CHAT": "Pin chat",
-      "UNPIN_CHAT": "Unpin chat"
+      "PIN_CHAT": "Fijar chat",
+      "UNPIN_CHAT": "Desfijar chat"
     },
     "MESSAGES": {
-      "PIN_SUCCESS": "Chat pinned",
-      "UNPIN_SUCCESS": "Chat unpinned",
-      "PIN_ERROR": "Error pinning chat",
-      "UNPIN_ERROR": "Error unpinning chat"
+      "PIN_SUCCESS": "Chat fijado",
+      "UNPIN_SUCCESS": "Chat desfijado",
+      "PIN_ERROR": "Error al fijar el chat",
+      "UNPIN_ERROR": "Error al desfijar el chat"
     }
   }
 }

--- a/src/app/private/agent-chat/agent-chat-list.component.ts
+++ b/src/app/private/agent-chat/agent-chat-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, signal } from '@angular/core';
+import { Component, inject, input, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { upperFirst } from 'lodash';
@@ -32,7 +32,10 @@ import { AgentChatService } from './agent-chat.service';
     class: 'list-page list-page--container',
   },
 })
-export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
+export class AgentChatListComponent
+  extends PaginatedListComponent<AgentChat>
+  implements OnInit
+{
   override dataSvc = inject(AgentChatService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
@@ -136,5 +139,10 @@ export class AgentChatListComponent extends PaginatedListComponent<AgentChat> {
   formatDate(timestamp: number): string {
     const date = new Date(timestamp);
     return date.toLocaleString();
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    this.chatSvc.loadPinnedChats();
   }
 }

--- a/src/app/private/layout/aside/aside.component.html
+++ b/src/app/private/layout/aside/aside.component.html
@@ -41,14 +41,29 @@
           <div class="collapse" [class.show]="!chatsCollapsed()">
             <div class="pinned-chats-container">
               @for (chat of pinnedChats(); track chat) {
-              <a
-                [routerLink]="['/private/chats', chat.id]"
-                routerLinkActive="nav-item-active"
-                class="text-muted pinned-chat-item p-2 text-decoration-none text-truncate d-block ps-4"
-                (click)="navigate.emit()"
-              >
-                {{ chat.title }}
-              </a>
+              <div class="pinned-chat-item d-flex align-items-center ps-4 pe-2">
+                <a
+                  class="flex-grow-1 text-muted text-decoration-none text-truncate"
+                  [routerLink]="['/private/chats', chat.id]"
+                  routerLinkActive="nav-item-active"
+                  (click)="navigate.emit()"
+                >
+                  {{ chat.title }}
+                </a>
+                <button
+                  type="button"
+                  class="btn btn-link p-0 ms-2 unpin-btn"
+                  (click)="togglePin(chat.id); $event.preventDefault(); $event.stopPropagation()"
+                  [title]="'CHATLIST.BUTTONS.UNPIN_CHAT' | transloco"
+                  [disabled]="loadingPins().has(chat.id)"
+                >
+                  @if (!loadingPins().has(chat.id)) {
+                  <i class="bi bi-pin-fill"></i>
+                  } @else {
+                  <span class="spinner-border spinner-border-sm"></span>
+                  }
+                </button>
+              </div>
               } @empty {
               <div class="alert alert-secondary" role="alert">
                 No tienes chats fijados

--- a/src/app/private/layout/aside/aside.component.scss
+++ b/src/app/private/layout/aside/aside.component.scss
@@ -69,6 +69,14 @@
       text-overflow: ellipsis;
       max-width: 150px;
     }
+
+    .unpin-btn {
+      visibility: hidden;
+    }
+
+    &:hover .unpin-btn {
+      visibility: visible;
+    }
   }
 }
 

--- a/src/app/private/layout/aside/aside.component.ts
+++ b/src/app/private/layout/aside/aside.component.ts
@@ -131,6 +131,7 @@ export class AsideComponent implements OnDestroy {
   chatsCollapsed = signal(true);
 
   pinnedChats = this.chatSvc.pinnedChats;
+  loadingPins = signal<Set<string>>(new Set());
 
   private userDropdown: any;
   private languageDropdown: any;
@@ -202,6 +203,19 @@ export class AsideComponent implements OnDestroy {
 
   logout() {
     this.auth.logout();
+  }
+
+  async togglePin(chatId: string): Promise<void> {
+    this.loadingPins.update((set) => new Set(set).add(chatId));
+    try {
+      await this.chatSvc.toggleChatPin(chatId);
+    } finally {
+      this.loadingPins.update((set) => {
+        const newSet = new Set(set);
+        newSet.delete(chatId);
+        return newSet;
+      });
+    }
   }
 
   currentUser = this.auth.user;


### PR DESCRIPTION
## Summary
- load pinned chats when the chat list component initializes
- translate Spanish strings for pin/unpin
- show unpin button for pinned chats in aside
- add hover styles and pin toggle logic

## Testing
- `npm install`
- `npx ng test --browsers=ChromiumHeadless --watch=false` *(fails: Chromium not available)*

------
https://chatgpt.com/codex/tasks/task_b_688880b123e88325aefed2924bff3c6f